### PR TITLE
Fixed bug where D strings were not converted to C strings properly when interfacing with FFmpeg

### DIFF
--- a/source/dcv/io/video/input.d
+++ b/source/dcv/io/video/input.d
@@ -1,6 +1,7 @@
 ﻿module dcv.io.video.input;
 
 import std.exception : enforce;
+import std.string;
 
 debug {
 	import std.stdio;
@@ -247,11 +248,11 @@ private:
 	}
 
 	bool openInputStreamImpl(AVInputFormat* inputFormat, in string filepath) {
-		const char* file = cast(const char*) filepath.dup.ptr;
+		const char* file = toStringz(filepath);
 		int streamIndex = -1;
 
 		// open file, and allocate format context
-		if (avformat_open_input(&formatContext, filepath.ptr, inputFormat, null) < 0) {
+		if (avformat_open_input(&formatContext, file, inputFormat, null) < 0) {
 			debug writeln("Could not open stream for file: " ~ filepath);
 			return false;
 		}

--- a/source/dcv/io/video/output.d
+++ b/source/dcv/io/video/output.d
@@ -5,6 +5,7 @@ debug {
 }
 
 import std.exception : enforce;
+import std.string;
 
 import ffmpeg.libavcodec.avcodec;
 import ffmpeg.libavformat.avformat;
@@ -57,7 +58,7 @@ public:
 	 */
 	bool open(in string filepath, in OutputDefinition props = OutputDefinition()) {
 		this.properties = props;
-		const char* path = (filepath.dup ~ '\0').ptr;
+		const char* path = toStringz(filepath);
 		char *formatString = null;
 
 		// Determinate output format


### PR DESCRIPTION
I found that FFmpeg was trying to read garbage after the end of the filepath string because null termination was not being done properly.
