### PR TITLE
Migration to ndslice.algorithm and Mir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
  - linux
 
 d:
- - dmd-2.070.0
+ - dmd-2.071.1
 
 addons:
  apt:

--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ Focus of the library is to present an easy-to-use interface, that would attract 
 
 ## API
 
-DCV's API heavily utilizes [std.experimental.ndslice](https://dlang.org/phobos/std_experimental_ndslice.html) package, which originated in [Mir](https://github.com/libmir/mir) project. It's n-dimensional range view structure [Slice](https://dlang.org/phobos/std_experimental_ndslice_slice.html#.Slice) is used for any form of image manipulation and processing. But overall shape of the API is adopted from well known computer vision toolkits such as Matlab Image Processing Toolbox, and OpenCV library, to be easily familiarized with. But it's also spiced up with D's syntactic sugar, to support pipelined calls:
+DCV's API heavily utilizes [Mir](https://github.com/libmir/mir) library, and it's `mir.ndslice` package. N-dimensional range view 
+structure [Slice](https://github.com/libmir/mir/blob/master/source/mir/ndslice/slice.d) is used for any form of image manipulation 
+and processing. But overall shape of the API is adopted from well known computer vision toolkits such as Matlab Image Processing 
+Toolbox, and OpenCV library, to be easily familiarized with. But it's also spiced up with D's syntactic sugar, to support pipelined calls:
 
 ```d
 Image image = imread("/path/to/image.png"); // read an image from filesystem.
 
-auto slice = image.sliced; // slice image data (calls std.experimental.ndslice.slice.sliced on image data)
+auto slice = image.sliced; // slice image data (calls mir.ndslice.slice.sliced on image data)
 
 slice
     .asType!float[0..$, 0..$, 1] // convert slice data to float, and take the green channel only.
     .conv!symmetric(sobel!float(GradientDirection.DIR_X)) // convolve image with horizontal Sobel kernel.
-    .byElement
-    .ranged(0, 255).array.sliced(slice.shape[0..2]) // scale values to fit the range between the 0 and 255
+    .ranged(0, 255) // scale values to fit the range between the 0 and 255
     .imshow("Sobel derivatives"); // preview changes on screen.
 
 waitKey();

--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "imageformats": "~>5.2.0",
         "scid": "~>0.3.0",
+        "mir": "~>0.16.0-alpha8",
         "ffmpeg-d": "2.5.0",
         "ggplotd": "~>0.9.4"
     },

--- a/examples/features/source/app.d
+++ b/examples/features/source/app.d
@@ -61,8 +61,7 @@ void visualizeCornerResponse(Slice!(2, float*) response, string windowName)
 {
     response 
         // scale values in the response matrix for easier visualization.
-        .byElement
-        .ranged(0., 255.).array.sliced(response.shape).asType!ubyte
+        .ranged(0., 255.).asType!ubyte
         // Show the window
         .imshow(windowName) 
         .image

--- a/examples/features/source/app.d
+++ b/examples/features/source/app.d
@@ -5,7 +5,7 @@ module dcv.example.imgmanip;
  */
 
 import std.stdio;
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.array : array;
 import std.algorithm.iteration : map, reduce;
 import std.range : repeat;

--- a/examples/filter/source/app.d
+++ b/examples/filter/source/app.d
@@ -62,8 +62,8 @@ int main(string[] args)
     // scale values from 0 to 255 to preview gradient direction and magnitude
     xgrads.ranged(0, 255);
     // Take absolute values and range them from 0 to 255, to preview edges
-    laplaceEdges = laplaceEdges.ndMap!(a => fabs(a)).byElement.array.sliced(laplaceEdges.shape).ranged(0.0f, 255.0f);
-    logEdges = logEdges.ndMap!(a => fabs(a)).byElement.array.sliced(logEdges.shape).ranged(0.0f, 255.0f);
+    laplaceEdges = laplaceEdges.ndMap!(a => fabs(a)).slice.ranged(0.0f, 255.0f);
+    logEdges = logEdges.ndMap!(a => fabs(a)).slice.ranged(0.0f, 255.0f);
 
     // Show images on screen
     img.imshow("Original");

--- a/examples/filter/source/app.d
+++ b/examples/filter/source/app.d
@@ -4,12 +4,13 @@ module dcv.example.convolution;
  * Spatial image filtering example using dcv library.
  */
 
-import mir.ndslice;
 import std.stdio : writeln;
 import std.datetime : StopWatch;
 import std.math : fabs;
 import std.array : array;
 import std.algorithm.iteration : map;
+
+import mir.ndslice;
 
 import dcv.core : Image, asType, ranged, ImageFormat;
 import dcv.io : imread, imwrite;
@@ -28,8 +29,9 @@ int main(string[] args)
         return 1;
     }
 
-    Slice!(3, float*) imslice = img.asType!float // convert Image data type from ubyte to float
-    .sliced!float; // slice image data - calls img.data!float.sliced(img.height, img.width, img.channels)
+    Slice!(3, float*) imslice = img
+        .asType!float // convert Image data type from ubyte to float
+        .sliced!float; // slice image data - calls img.data!float.sliced(img.height, img.width, img.channels)
 
     auto gray = imslice.rgb2gray; // convert rgb image to grayscale
 
@@ -58,10 +60,10 @@ int main(string[] args)
     auto medBlur = noisyImage.medianFilter(5);
 
     // scale values from 0 to 255 to preview gradient direction and magnitude
-    xgrads = xgrads.byElement.ranged(0, 255).array.sliced(xgrads.shape);
+    xgrads.ranged(0, 255);
     // Take absolute values and range them from 0 to 255, to preview edges
-    laplaceEdges = laplaceEdges.byElement.map!(a => fabs(a)).ranged(0, 255).array.sliced(laplaceEdges.shape);
-    logEdges = logEdges.byElement.map!(a => fabs(a)).ranged(0, 255).array.sliced(logEdges.shape);
+    laplaceEdges = laplaceEdges.ndMap!(a => fabs(a)).byElement.array.sliced(laplaceEdges.shape).ranged(0.0f, 255.0f);
+    logEdges = logEdges.ndMap!(a => fabs(a)).byElement.array.sliced(logEdges.shape).ranged(0.0f, 255.0f);
 
     // Show images on screen
     img.imshow("Original");

--- a/examples/filter/source/app.d
+++ b/examples/filter/source/app.d
@@ -4,7 +4,7 @@ module dcv.example.convolution;
  * Spatial image filtering example using dcv library.
  */
 
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.stdio : writeln;
 import std.datetime : StopWatch;
 import std.math : fabs;

--- a/examples/imgmanip/source/app.d
+++ b/examples/imgmanip/source/app.d
@@ -5,7 +5,7 @@ module dcv.example.imgmanip;
  */
 
 import std.stdio;
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core;
 import dcv.imgproc.imgmanip;

--- a/examples/rht/source/app.d
+++ b/examples/rht/source/app.d
@@ -4,11 +4,12 @@ module dcv.example.rht;
  * Randomized Hough Transform example using dcv library.
  */
 
-import std.experimental.ndslice;
 import std.stdio : writeln;
 import std.datetime : StopWatch;
 import std.math : fabs, PI, sin, cos, rint;
 import std.typecons : tuple;
+
+import mir.ndslice;
 
 import dcv.core : Image, asType, ranged, ImageFormat;
 import dcv.io : imread, imwrite;

--- a/examples/tracking/hornschunck/source/app.d
+++ b/examples/tracking/hornschunck/source/app.d
@@ -7,7 +7,7 @@ module dcv.example.opticalflow;
 
 import std.stdio;
 import std.conv : to;
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core;
 import dcv.io;

--- a/examples/tracking/klt/source/app.d
+++ b/examples/tracking/klt/source/app.d
@@ -9,7 +9,7 @@ import std.conv : to;
 import std.algorithm : copy, map, each;
 import std.range : lockstep, repeat;
 import std.array : array;
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core;
 import dcv.io;

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -4,7 +4,7 @@ Module implements various algorithms used often in computer vision.
 $(DL Module contains:
     $(DD 
             $(LINK2 #norm,norm)
-            $(LINK2 #normalize,normalize)
+            $(LINK2 #normalized,normalized)
             $(LINK2 #scaled,scaled)
             $(LINK2 #ranged,ranged)
     )

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -3,8 +3,6 @@ Module implements various algorithms used often in computer vision.
 
 $(DL Module contains:
     $(DD 
-            $(LINK2 #findMin,findMin)
-            $(LINK2 #findMax,findMax)
             $(LINK2 #norm,norm)
             $(LINK2 #normalize,normalize)
             $(LINK2 #scaled,scaled)

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -22,10 +22,15 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 module dcv.core.algorithm;
 
 import std.range;
-import std.traits : isNumeric, isAssignable;
-import std.algorithm : map, each, max, min, reduce;
+import std.traits : isNumeric, isFloatingPoint;
 
-import mir.ndslice;
+import mir.ndslice.slice : Slice, sliced, DeepElementType;
+import mir.ndslice.algorithm : ndFold, ndReduce, ndEach, Yes;
+
+version(unittest)
+{
+    import std.math : sqrt, approxEqual;
+}
 
 /**
 Type of matrix and vector norms.
@@ -37,252 +42,245 @@ enum NormType
     L2 /// Eucledian norm, sqrt(sum(x^^2))
 }
 
-private ElementType!Range findMinMax(string comparator, Range)(Range range) pure nothrow 
-        if (isForwardRange!Range && isNumeric!(ElementType!Range))
-{
-    ElementType!Range v = range.front;
-    mixin("foreach(e; range) { if (e " ~ comparator ~ " v) v = e; }");
-    return v;
-}
-
-/**
-Find minimum value in the forward range.
-
-Params:
-    range = Forward range in which minimum value is looked for.
-
-Returns:
-    Minimum value of all elements in given range.
-*/
-ElementType!Range findMin(Range)(Range range) pure nothrow 
-        if (isForwardRange!Range && isNumeric!(ElementType!Range))
-{
-    return range.findMinMax!"<";
-}
-
-/// Find minimal value in the array.
-unittest
-{
-    auto arr = [1, 2, 3];
-    assert(arr.findMin == 1);
-}
-
-/**
-Find maximum value in the forward range.
-
-Params:
-    range = Forward range in which maximum value is looked for.
-
-Returns:
-    Maximum value of all elements in given range.
-*/
-ElementType!Range findMax(Range)(Range range) pure nothrow 
-        if (isForwardRange!Range && isNumeric!(ElementType!Range))
-{
-    return range.findMinMax!">";
-}
-
-/// Find maximal value in the array.
-unittest
-{
-    auto arr = [1, 2, 3];
-    assert(arr.findMax == 3);
-}
-
 /**
 Calculate value of various norm types for vectors and matrices.
 
 Params:
-    range = Forward range that represents vector or matrix of which the norm is calculated.
+    tensor = Tensor of which the norm value is calculated.
     normType = requested type of norm.
 
 Returns:
-Calculated norm value as real.
+    Calculated norm value as real.
 */
-real norm(Range)(Range range, in NormType normType)
-        if (isForwardRange!Range && isNumeric!(ElementType!Range)
-            && isAssignable!(real, ElementType!Range))
+@nogc pure nothrow real norm(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType)
 {
+    import std.algorithm.comparison : max;
+    import std.conv : to;
+
+    version (LDC)
+        import ldc.intrinsics : sqrt = llvm_sqrt, abs = llvm_abs;
+    else
+        import std.math : sqrt, abs;
+
+    alias T = DeepElementType!(typeof(tensor));
+
+    static if (isFloatingPoint!T)
+        auto min = T.min_normal;
+    else
+        auto min = T.min;
+
     final switch (normType)
     {
     case NormType.INF:
-        return range.normImpl_inf;
+        return min.ndReduce!max(tensor).to!real;
     case NormType.L1:
-        return range.normImpl_n1;
+        return T(0).ndReduce!((a, b) => abs(a + b))(tensor).to!real;
     case NormType.L2:
-        return range.normImpl_n2;
+        return T(0).ndReduce!((a, b) => a + b ^^ 2)(tensor).to!real.sqrt;
     }
 }
 
-unittest
+// Test INF norm
+pure nothrow unittest
 {
-    import std.math : sqrt, approxEqual;
+    import std.conv : to;
 
-    auto arr = [1.0f, 2.0f, 3.0f];
-    assert(approxEqual(arr.norm(NormType.INF), 3.0f));
-    assert(approxEqual(arr.norm(NormType.L1), ((arr[0] + arr[1] + arr[2]))));
-    assert(approxEqual(arr.norm(NormType.L2), sqrt(arr[0] ^^ 2 + arr[1] ^^ 2 + arr[2] ^^ 2)));
+    auto t1 = tensor1();
+    auto t2 = tensor2();
+    auto t3 = tensor3();
+
+    assert(approxEqual(t1.norm(NormType.INF), 3.0f));
+    assert(approxEqual(t2.norm(NormType.INF), 9.0f));
+    assert(approxEqual(t3.norm(NormType.INF), 27.0f));
+}
+
+// Test L1 norm - test vector sum == 1 after normalization
+pure nothrow unittest
+{
+    auto t1 = tensor1();
+    auto t2 = tensor2();
+    auto t3 = tensor3();
+
+    t1[] /= t1.norm(NormType.L1);
+    t2[] /= t2.norm(NormType.L1);
+    t3[] /= t3.norm(NormType.L1);
+
+    assert(approxEqual(t1.ndFold!"a+b"(0.0f), 1.0f));
+    assert(approxEqual(t2.ndFold!"a+b"(0.0f), 1.0f));
+    assert(approxEqual(t3.ndFold!"a+b"(0.0f), 1.0f));
+}
+
+// Test L2 norm - test vector length == 1 after normalization
+pure nothrow unittest
+{
+    auto t1 = tensor1();
+    auto t2 = tensor2();
+    auto t3 = tensor3();
+
+    t1[] /= t1.norm(NormType.L2);
+    t2[] /= t2.norm(NormType.L2);
+    t3[] /= t3.norm(NormType.L2);
+
+    assert(approxEqual(t1.ndFold!( (v, n) => v + n*n)(0.0f), 1.0f));
+    assert(approxEqual(t2.ndFold!( (v, n) => v + n*n)(0.0f), 1.0f));
+    assert(approxEqual(t3.ndFold!( (v, n) => v + n*n)(0.0f), 1.0f));
 }
 
 /**
-Normalize range using given norm type.
-
-Performs lazy normalization by utilizing std.algorithm.iteration.map.
+Normalize tensor values using given norm type.
 
 Params:
-    range = Forward range that represent vector or matrix which is normalized.
-    normType = requested norm type for normalization.
+    tensor = Tensor which is normalized.
+    normType = Requested norm type for normalization.
 
 Returns:
-    Returns the map result range that evaluates normalization lazily.
+    Returns normalized input tensor.
 */
-auto normalize(Range)(Range range, NormType normType = NormType.L2)
-        if (isForwardRange!Range && isAssignable!(real, ElementType!Range))
+@nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
 {
-    // TODO: redesign as pure
-    auto n = range.norm(normType);
-    return range.map!(v => v / n);
-}
-
-unittest
-{
-    import std.algorithm.comparison : equal;
-    import std.math : sqrt, approxEqual;
-
-    auto arr = [0.0, 1.0, 2.0];
-    auto infNorm = 2.0;
-    auto l1Norm = 3.0;
-    auto l2Norm = sqrt(5.0);
-    assert(equal!approxEqual([arr[0] / infNorm, arr[1] / infNorm,
-            arr[2] / infNorm], arr.normalize(NormType.INF).array));
-    assert(equal!approxEqual([arr[0] / l1Norm, arr[1] / l1Norm, arr[2] / l1Norm],
-            arr.normalize(NormType.L1).array));
-    assert(equal!approxEqual([arr[0] / l2Norm, arr[1] / l2Norm, arr[2] / l2Norm],
-            arr.normalize(NormType.L2).array));
-}
-
-/**
-Scale range values by shift and multiplication.
-
-Performs value scaling by multiplication and shifting by following equation:
-$(D_CODE $(D_PARAM out) = $(D_PARAM alpha)*$(D_PARAM range) + $(D_PARAM beta))
-
-Performs lazy scale of the values by utilizing std.algorithm.iteration.map.
-
-Params:
-    range = Forward range in which values are being scaled.
-    alpha = Multiplier value.
-    beta = Shift value.
-
-Returns:
-    Returns the map result range that evaluates value scaling lazily.
-*/
-auto scaled(Scalar, Range)(Range range, Scalar alpha = 1, Scalar beta = 0) pure @safe nothrow 
-        if (isForwardRange!Range && isNumeric!(ElementType!Range)
-            && isNumeric!Scalar && isAssignable!(ElementType!Range, Scalar))
-{
-    static if (is(ElementType!Range == Scalar))
-        return range.map!(v => alpha * (v) + beta);
+    alias T = DeepElementType!(typeof(tensor));
+    auto n = tensor.norm(normType);
+    static if (isFloatingPoint!T)
+        tensor[] /= n;
     else
-        return range.map!(v => cast(ElementType!Range)(alpha * (v) + beta));
+        tensor.ndEach!((ref v) { v = cast(T)(cast(real)v / n); }, Yes.vectorized);
+    return tensor;
 }
 
-///
-unittest
+nothrow unittest
 {
-    auto arr = [0.0, 0.5, 1.0];
-    arr = arr.scaled(10.0, 2.0).array;
-    assert(arr[0] == 2.0);
-    assert(arr[1] == 7.0);
-    assert(arr[2] == 12.0);
+    auto t = tensor1();
+    auto tn = normalized(t, NormType.L1);
+    assert(t.ptr == tn.ptr);
 }
 
 /**
-Scale range values to fit a given value range.
-
-Performs lazy scale of the values by utilizing std.algorithm.iteration.map.
+Scale tensor values.
 
 Params:
-    range = Forward range in which values are being scaled.
-    min = Minimal range value.
-    max = Maximal range value.
+    tensor = Input tensor.
+    alpha = Multiplier value.
+    beta = Offset value.
+
+Performs value modification of tensor elements using following formula:
+----
+out = alpha * (in) + beta;
+----
 
 Returns:
-    Returns the map result range that evaluates value scaling lazily.
+    Scaled input tensor.
+    
 */
-auto ranged(Scalar, Range)(Range range, Scalar min = 0, Scalar max = 1)
-        if (isForwardRange!Range && isNumeric!(ElementType!Range)
-            && isNumeric!Scalar && isAssignable!(ElementType!Range, Scalar))
+@nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
+        if (isNumeric!Scalar)
+{
+    tensor.ndEach!((ref v) { v = alpha * (v) + beta; }, Yes.vectorized);
+    return tensor;
+}
+
+nothrow unittest
+{
+    auto t = tensor1();
+    auto ts = t.scaled(10.0f, 2.0f);
+
+    assert(t.ptr == ts.ptr);
+
+    assert(approxEqual(ts[0], 12.0f));
+    assert(approxEqual(ts[1], 22.0f));
+    assert(approxEqual(ts[2], 32.0f));
+}
+
+/**
+In-place tensor scaling to fit given value range.
+
+Params:
+    tensor = Input tensor.
+    minValue = Minimal value output tensor should contain.
+    maxValue = Maximal value output tensor should contain.
+
+*/
+@nogc auto ranged(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor,
+        Scalar minValue = 0, Scalar maxValue = 1) if (isNumeric!Scalar)
 {
     import std.traits : isFloatingPoint;
+    import std.algorithm.comparison : min, max;
 
-    auto _min = range.findMin;
-    auto _max = range.findMax;
-    auto _d = _max - _min;
-    static if (isFloatingPoint!Scalar)
-    {
-        auto sc_val = (max / _d);
-        static if (is(ElementType!Range == Scalar))
-            return range.map!(a => (a - _min) * sc_val);
-        else
-            return range.map!(a => cast(ElementType!Range)((a - _min) * sc_val));
-    }
+    alias RangeElementType = DeepElementType!(typeof(tensor));
+
+    auto _min = tensor.ndFold!min(RangeElementType.max);
+    static if (isFloatingPoint!RangeElementType)
+        auto _max = tensor.ndFold!max(RangeElementType.min_normal);
     else
+        auto _max = tensor.ndFold!max(RangeElementType.min);
+
+    auto rn_val = _max - _min;
+    auto sc_val = maxValue - minValue;
+
+    tensor.ndEach!((ref a) { a = sc_val * ((a - _min) / rn_val) + minValue; }, Yes.vectorized);
+
+    return tensor;
+}
+
+unittest
+{
+    immutable smin = -10.0f;
+    immutable smax = 15.0f;
+
+    auto t1 = tensor1();
+    auto t2 = tensor2();
+    auto t3 = tensor3();
+
+    auto t1r = t1.ranged(smin, smax);
+    auto t2r = t2.ranged(smin, smax);
+    auto t3r = t3.ranged(smin, smax);
+
+    assert(t1.ptr == t1r.ptr);
+    assert(t2.ptr == t2r.ptr);
+    assert(t3.ptr == t3r.ptr);
+
+}
+
+nothrow unittest
+{
+    import std.algorithm.comparison : max, min;
+
+    immutable smin = -10.0f;
+    immutable smax = 15.0f;
+
+    auto t1 = tensor1();
+    auto t2 = tensor2();
+    auto t3 = tensor3();
+
+    auto t1r = t1.ranged(smin, smax);
+    auto t2r = t2.ranged(smin, smax);
+    auto t3r = t3.ranged(smin, smax);
+
+    assert(approxEqual(ndFold!min(t1r, float.max), smin));
+    assert(approxEqual(ndFold!max(t1r, float.min_normal), smax));
+
+    assert(approxEqual(ndFold!min(t2r, float.max), smin));
+    assert(approxEqual(ndFold!max(t2r, float.min_normal), smax));
+
+    assert(approxEqual(ndFold!min(t3r, float.max), smin));
+    assert(approxEqual(ndFold!max(t3r, float.min_normal), smax));
+}
+
+version (unittest)
+{
+    auto tensor1()
     {
-        auto sc_val = cast(float)(max / _d);
-        return range.map!(a => cast(ElementType!Range)(cast(float)(a - _min) * sc_val));
+        return [1.0f, 2.0f, 3.0f].sliced(3);
     }
-}
 
-///
-unittest
-{
-    auto arr = [0.0, 0.5, 1.0].ranged(0, 10).array;
-    assert(arr[0] == 0.);
-    assert(arr[1] == 5.);
-    assert(arr[2] == 10.);
-}
-
-unittest
-{
-    auto arr = [0.0, 0.5, 1.0].ranged(0.0, 10.0).array;
-    assert(arr[0] == 0.);
-    assert(arr[1] == 5.);
-    assert(arr[2] == 10.);
-}
-
-unittest
-{
-    auto arr = [0.0, 0.5, 1.0].ranged(0.0f, 10.0f).array;
-    assert(arr[0] == 0.);
-    assert(arr[1] == 5.);
-    assert(arr[2] == 10.);
-}
-
-private: // implementation
-
-// basic norm implementation ////////
-
-auto normImpl_inf(Range)(Range range)
-{
-    return range.findMax;
-}
-
-auto normImpl_n1(Range)(Range range)
-{
-    import std.math : abs;
-
-    return range.reduce!((a, b) => abs(a + b));
-}
-
-auto normImpl_n2(Range)(Range range)
-{
-    import std.math : sqrt;
-
-    ElementType!Range v = 0;
-    foreach (e; range)
+    auto tensor2()
     {
-        v += e ^^ 2;
+        return [1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f].sliced(3, 3);
     }
-    return sqrt(v);
+
+    auto tensor3()
+    {
+        return [1.0f, 2.0f, 3.0f,       4.0f, 5.0f, 6.0f,       7.0f, 8.0f, 9.0f, 
+               10.0f, 11.0f, 12.0f,     13.0f, 14.0f, 15.0f,    16.0f, 17.0f, 18.0f, 
+               19.0f, 20.0f, 21.0f,     22.0f, 23.0f, 24.0f,    25.0f, 26.0f, 27.0f].sliced(3, 3, 3);
+    }
 }

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -21,10 +21,11 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.core.algorithm;
 
-import std.experimental.ndslice;
 import std.range;
 import std.traits : isNumeric, isAssignable;
 import std.algorithm : map, each, max, min, reduce;
+
+import mir.ndslice;
 
 /**
 Type of matrix and vector norms.

--- a/source/dcv/core/image.d
+++ b/source/dcv/core/image.d
@@ -2,7 +2,7 @@
 Module implements Image utility class, and basic API for image manipulation.
 
 Image class encapsulates image properties with minimal functionality. It is primarily designed to be used as I/O unit.
-For any image processing needs, image data can be sliced to std.experimental.ndslice.slice.Slice. 
+For any image processing needs, image data can be sliced to mir.ndslice.slice.Slice. 
 
 Example:
 ----
@@ -27,7 +27,7 @@ module dcv.core.image;
 import std.exception : enforce;
 import std.algorithm : reduce;
 
-public import std.experimental.ndslice;
+public import mir.ndslice;
 
 /// Image (pixel) format.
 enum ImageFormat

--- a/source/dcv/core/memory.d
+++ b/source/dcv/core/memory.d
@@ -101,7 +101,7 @@ unittest
 {
     // TODO: design the test...
 
-    import std.experimental.ndslice;
+    import mir.ndslice;
 
     int[] arr = allocArray!int(3);
     scope (exit)

--- a/source/dcv/core/utils.d
+++ b/source/dcv/core/utils.d
@@ -9,11 +9,12 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.core.utils;
 
-import mir.ndslice;
 import std.traits;
 import std.meta : allSatisfy;
 import std.range : lockstep;
 import std.algorithm.iteration : reduce;
+
+import mir.ndslice;
 
 /// Check if an type is a Slice.
 enum bool isSlice(T) = is(T : Slice!(N, Range), size_t N, Range);

--- a/source/dcv/core/utils.d
+++ b/source/dcv/core/utils.d
@@ -9,7 +9,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.core.utils;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.traits;
 import std.meta : allSatisfy;
 import std.range : lockstep;

--- a/source/dcv/features/corner/fast/package.d
+++ b/source/dcv/features/corner/fast/package.d
@@ -16,7 +16,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.features.corner.fast;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core.image : BitDepth;
 import dcv.features.utils : Feature;

--- a/source/dcv/features/corner/fast/package.d
+++ b/source/dcv/features/corner/fast/package.d
@@ -14,9 +14,9 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 1. Edward Rosten, Tom Drummond (2005). "Fusing points and lines for high performance tracking", IEEE International Conference on Computer Vision 2: 1508–1511.
 */
 
-module dcv.features.corner.fast;
-
 import mir.ndslice;
+
+module dcv.features.corner.fast;
 
 import dcv.core.image : BitDepth;
 import dcv.features.utils : Feature;

--- a/source/dcv/features/corner/fast/package.d
+++ b/source/dcv/features/corner/fast/package.d
@@ -13,10 +13,10 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 1. Edward Rosten, Tom Drummond (2005). "Fusing points and lines for high performance tracking", IEEE International Conference on Computer Vision 2: 1508–1511.
 */
+module dcv.features.corner.fast;
 
 import mir.ndslice;
 
-module dcv.features.corner.fast;
 
 import dcv.core.image : BitDepth;
 import dcv.features.utils : Feature;

--- a/source/dcv/features/corner/harris.d
+++ b/source/dcv/features/corner/harris.d
@@ -9,7 +9,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.features.corner.harris;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core.utils : emptySlice;
 import dcv.imgproc.filter : calcPartialDerivatives;

--- a/source/dcv/features/detector/package.d
+++ b/source/dcv/features/detector/package.d
@@ -9,7 +9,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.features.detector;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 public import dcv.core.image : Image;
 public import dcv.features.utils : Feature;

--- a/source/dcv/features/rht.d
+++ b/source/dcv/features/rht.d
@@ -35,8 +35,9 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.features.rht;
 
-import mir.ndslice;
 import std.typecons, std.range.primitives;
+
+import mir.ndslice;
 
 /++
     A template that bootstraps a full Randomized Hough transform implementation.

--- a/source/dcv/features/rht.d
+++ b/source/dcv/features/rht.d
@@ -35,7 +35,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.features.rht;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.typecons, std.range.primitives;
 
 /++

--- a/source/dcv/features/utils.d
+++ b/source/dcv/features/utils.d
@@ -10,7 +10,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.features.utils;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.traits : isNumeric;
 
 /**

--- a/source/dcv/features/utils.d
+++ b/source/dcv/features/utils.d
@@ -10,8 +10,9 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.features.utils;
 
-import mir.ndslice;
 import std.traits : isNumeric;
+
+import mir.ndslice;
 
 /**
 Feature point.

--- a/source/dcv/imgproc/color.d
+++ b/source/dcv/imgproc/color.d
@@ -35,10 +35,6 @@ luv2rgb -||-
 bayer2rgb -||-
 */
 
-import mir.ndslice;
-
-import dcv.core.utils;
-
 import std.array : uninitializedArray;
 import std.traits : CommonType, isFloatingPoint, isAssignable, isNumeric;
 import std.algorithm.iteration : sum, each, reduce, map;
@@ -49,6 +45,10 @@ import std.range : zip, array, iota;
 import std.parallelism : parallel;
 import std.exception : enforce;
 import std.range : lockstep;
+
+import mir.ndslice;
+
+import dcv.core.utils;
 
 /**
 RGB to Grayscale convertion strategy.

--- a/source/dcv/imgproc/color.d
+++ b/source/dcv/imgproc/color.d
@@ -35,7 +35,7 @@ luv2rgb -||-
 bayer2rgb -||-
 */
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core.utils;
 

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -43,20 +43,21 @@ separable_conv
 v0.1+ plans:
 1d_conv_simd
 */
-import dcv.core.memory;
-import dcv.core.utils;
 
 import std.traits : isAssignable;
 import std.range;
 import std.algorithm.comparison : equal;
-
-import mir.ndslice;
 
 import std.algorithm.iteration : reduce;
 import std.algorithm.comparison : max, min;
 import std.exception : enforce;
 import std.parallelism : parallel;
 import std.math : abs, floor;
+
+import mir.ndslice;
+
+import dcv.core.memory;
+import dcv.core.utils;
 
 /**
 Perform convolution to given range, using given kernel.

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -50,7 +50,7 @@ import std.traits : isAssignable;
 import std.range;
 import std.algorithm.comparison : equal;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import std.algorithm.iteration : reduce;
 import std.algorithm.comparison : max, min;

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -717,7 +717,9 @@ Slice!(2, V*) canny(V, T)(Slice!(2, T*) slice, T lowThresh, T upThresh,
     calcGradients(slice, mag, orient, edgeKernelType);
     auto nonmax = nonMaximaSupression(mag, orient);
 
-    return nonmax.byElement.ranged(0, upval).array.sliced(nonmax.shape).threshold!V(lowThresh, upThresh);
+    return nonmax
+        .ranged(0, upval)
+        .threshold!V(lowThresh, upThresh);
 }
 
 /**
@@ -800,7 +802,7 @@ body
             }
 
             // normalize mask and calculate result value.
-            float mask_sum = mask.byElement.norm(NormType.L1);
+            float mask_sum = mask.norm(NormType.L1);
             float res_val = 0.0f;
 
             i = 0;

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -41,7 +41,7 @@ $(DL Module contains:
 
 module dcv.imgproc.filter;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import std.traits : allSameType, allSatisfy, isFloatingPoint, isNumeric, isDynamicArray,
     isStaticArray,isIntegral;

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -41,8 +41,6 @@ $(DL Module contains:
 
 module dcv.imgproc.filter;
 
-import mir.ndslice;
-
 import std.traits : allSameType, allSatisfy, isFloatingPoint, isNumeric, isDynamicArray,
     isStaticArray,isIntegral;
 import std.range : iota, array, lockstep, ElementType, isForwardRange;
@@ -58,6 +56,7 @@ import std.parallelism : parallel, taskPool;
 import dcv.core.algorithm;
 import dcv.core.utils;
 
+import mir.ndslice;
 
 /**
 Box kernel creation.

--- a/source/dcv/imgproc/imgmanip.d
+++ b/source/dcv/imgproc/imgmanip.d
@@ -18,13 +18,9 @@ $(DL Module contains:
     )
 )
 */
-
 module dcv.imgproc.imgmanip;
 
-public import dcv.imgproc.interpolate;
-
 import std.exception : enforce;
-import mir.ndslice;
 import std.traits : allSatisfy, isFloatingPoint, allSameType, isNumeric, isIntegral;
 import std.algorithm : each;
 import std.range : iota;
@@ -32,6 +28,9 @@ import std.parallelism : parallel;
 import std.range : isArray, ElementType;
 
 import dcv.core.utils;
+public import dcv.imgproc.interpolate;
+
+import mir.ndslice;
 
 /**
 Resize array using custom interpolation function.

--- a/source/dcv/imgproc/imgmanip.d
+++ b/source/dcv/imgproc/imgmanip.d
@@ -24,7 +24,7 @@ module dcv.imgproc.imgmanip;
 public import dcv.imgproc.interpolate;
 
 import std.exception : enforce;
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.traits : allSatisfy, isFloatingPoint, allSameType, isNumeric, isIntegral;
 import std.algorithm : each;
 import std.range : iota;

--- a/source/dcv/imgproc/interpolate.d
+++ b/source/dcv/imgproc/interpolate.d
@@ -7,19 +7,7 @@ Authors: Relja Ljubobratovic
 
 License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - Version 1.0).
 */
-
 module dcv.imgproc.interpolate;
-/**
- 
- * 
- * v0.1 norm:
- * nn
- * linear
- * cubic
- * 
- * v0.1+:
- * lanczos?
- */
 
 import std.range : isRandomAccessRange, ElementType;
 import std.traits : isNumeric, isScalarType, isIntegral, allSameType, allSatisfy, ReturnType,

--- a/source/dcv/imgproc/interpolate.d
+++ b/source/dcv/imgproc/interpolate.d
@@ -26,7 +26,7 @@ import std.traits : isNumeric, isScalarType, isIntegral, allSameType, allSatisfy
     isFloatingPoint;
 import std.exception;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 /**
 Test if given function is proper form for interpolation.

--- a/source/dcv/imgproc/threshold.d
+++ b/source/dcv/imgproc/threshold.d
@@ -9,7 +9,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.imgproc.threshold;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core.utils : emptySlice;
 

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -79,17 +79,16 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 module dcv.plot.figure;
 
 import std.string : toStringz;
-import mir.ndslice;
 import std.exception;
 import std.conv : to;
+
+import mir.ndslice;
 
 import ggplotd.ggplotd, ggplotd.aes, ggplotd.axes, ggplotd.geom;
 
 import dcv.core.image : Image, ImageFormat, BitDepth, asImage;
 import dcv.core.utils : asType;
-
 import dcv.plot.bindings;
-
 
 /**
 Create a plotting figure.

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -79,7 +79,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 module dcv.plot.figure;
 
 import std.string : toStringz;
-import std.experimental.ndslice;
+import mir.ndslice;
 import std.exception;
 import std.conv : to;
 

--- a/source/dcv/plot/opticalflow.d
+++ b/source/dcv/plot/opticalflow.d
@@ -10,7 +10,8 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.plot.opticalflow;
 
-import mir.ndslice;
+import mir.ndslice.slice : Slice, sliced;
+import mir.ndslice.algorithm : Yes, ndEach;
 
 /**
  * Draw color-coded optical flow.
@@ -29,7 +30,6 @@ Slice!(3, ubyte*) colorCode(Slice!(3, float*) flow, float maxSize = 0)
 {
     import std.math : sqrt;
     import std.array : array;
-    import std.algorithm.iteration : map;
 
     import dcv.core.algorithm : ranged;
     import dcv.imgproc.color : hsv2rgb;
@@ -61,13 +61,9 @@ Slice!(3, ubyte*) colorCode(Slice!(3, float*) flow, float maxSize = 0)
         }
     }
 
-    // Range saturation values
-    auto rangedS = hsv[0 .. $, 0 .. $, 1].byElement.ranged(0.0f,
-            maxSize) // range values from 0 to maxSize
-    .map!(v => v / maxSize) // normalize values
-    .array.sliced(hsv[0 .. $, 0 .. $, 0].shape);
+    hsv[0 .. $, 0 .. $, 1]
+        .ranged(0.0f, maxSize)
+        .ndEach!( (ref v) { v/= maxSize; }, Yes.vectorized);
 
-    hsv[0 .. $, 0 .. $, 1][] = rangedS[];
-
-    return hsv.hsv2rgb!ubyte;
+    return hsv.hsv2rgb!ubyte; // Convert to RGB, and return...
 }

--- a/source/dcv/plot/opticalflow.d
+++ b/source/dcv/plot/opticalflow.d
@@ -10,7 +10,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.plot.opticalflow;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 /**
  * Draw color-coded optical flow.

--- a/source/dcv/tracking/opticalflow/base.d
+++ b/source/dcv/tracking/opticalflow/base.d
@@ -10,6 +10,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 module dcv.tracking.opticalflow.base;
 
 public import mir.ndslice : Slice;
+
 public import dcv.core.image : Image;
 public import dcv.core.utils : emptySlice;
 

--- a/source/dcv/tracking/opticalflow/base.d
+++ b/source/dcv/tracking/opticalflow/base.d
@@ -9,7 +9,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 */
 module dcv.tracking.opticalflow.base;
 
-public import std.experimental.ndslice : Slice;
+public import mir.ndslice : Slice;
 public import dcv.core.image : Image;
 public import dcv.core.utils : emptySlice;
 

--- a/source/dcv/tracking/opticalflow/hornschunck.d
+++ b/source/dcv/tracking/opticalflow/hornschunck.d
@@ -10,7 +10,7 @@ License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - 
 
 module dcv.tracking.opticalflow.hornschunck;
 
-import std.experimental.ndslice;
+import mir.ndslice;
 
 import dcv.core.image;
 import dcv.tracking.opticalflow.base;

--- a/source/dcv/tracking/opticalflow/lucaskanade.d
+++ b/source/dcv/tracking/opticalflow/lucaskanade.d
@@ -14,9 +14,7 @@ import std.math : PI, floor;
 
 import dcv.core.image;
 import dcv.imgproc.convolution;
-
 import dcv.tracking.opticalflow.base;
-
 public import dcv.imgproc.interpolate;
 
 /**

--- a/source/dcv/tracking/opticalflow/lucaskanade.d
+++ b/source/dcv/tracking/opticalflow/lucaskanade.d
@@ -61,22 +61,27 @@ class LucasKanadeFlow : SparseOpticalFlow
     }
     body
     {
+        import std.array : uninitializedArray;
+        import std.range : lockstep, iota;
+        import std.array : array;
+        import std.algorithm.iteration : each;
+        import std.parallelism : parallel;
+
+        import mir.ndslice.slice : assumeSameStructure;
+        import mir.ndslice.algorithm : ndEach, Yes;
+
         import dcv.core.algorithm : ranged, ranged;
         import dcv.imgproc.interpolate : linear;
         import dcv.imgproc.filter;
         import dcv.core.utils : asType;
-
-        import std.array : uninitializedArray;
-        import std.range : lockstep, iota;
-        import std.array : array;
-        import std.algorithm.iteration : map;
-        import std.parallelism : parallel;
+        import dcv.core.memory;
 
         const auto rows = f1.height;
         const auto cols = f1.width;
         const auto rl = cast(int)(rows - 1);
         const auto cl = cast(int)(cols - 1);
         const auto pointCount = points.length;
+        const auto pixelCount = rows * cols;
 
         if (!usePrevious)
         {
@@ -90,37 +95,42 @@ class LucasKanadeFlow : SparseOpticalFlow
         float gaussMul = 1.0f / (2.0f * PI * sigma);
         float gaussDel = 2.0f * (sigma ^^ 2);
 
-        auto f1s = new float[f1.height*f1.width].sliced(f1.height, f1.width);
-        auto f2s = new float[f1.height*f1.width].sliced(f1.height, f1.width);
+        // Temporary buffers, used in alrithm -------------------------------
+        // TODO: cache these in class, and reuse
+        auto floatPool = [
+            alignedAlloc!float(pixelCount), alignedAlloc!float(pixelCount),
+            alignedAlloc!float(pixelCount), alignedAlloc!float(pixelCount)
+        ];
+        auto ubytePool = [alignedAlloc!ubyte(pixelCount), alignedAlloc!ubyte(pixelCount)];
 
-        auto fxs = new float[f1.height*f1.width].sliced(f1.height, f1.width);
-        auto fys = new float[f1.height*f1.width].sliced(f1.height, f1.width);
-
-        auto f1d = f1.data;
-        auto f2d = f2.data;
-
-        foreach(r; iota(f1.height).parallel)
+        scope (exit)
         {
-            foreach(c; 0 .. f1.width)
-            {
-                auto id = r * f1.width + c;
-                f1s[r, c] = cast(float)f1d[id];
-                f2s[r, c] = cast(float)f2d[id];
-            }
+            floatPool.each!(v => alignedFree(v));
+            ubytePool.each!(v => alignedFree(v));
         }
+        // --------------------------------------------------------------------
 
+        auto f1s = floatPool[0].sliced(rows, cols);
+        auto f2s = floatPool[1].sliced(rows, cols);
+        auto fxs = floatPool[2].sliced(rows, cols);
+        auto fys = floatPool[3].sliced(rows, cols);
+        auto fxmask = ubytePool[0].sliced(rows, cols);
+        auto fymask = ubytePool[1].sliced(rows, cols);
+        auto f1d = f1.data.sliced(f1s.shape);
+        auto f2d = f2.data.sliced(f2s.shape);
 
-        auto fxmask = new ubyte[f1.height * f1.width].sliced(f1.height, f1.width);
-        auto fymask = new ubyte[f1.height * f1.width].sliced(f1.height, f1.width);
+        assumeSameStructure!("f1s", "f2s", "f1", "f2")(f1s, f2s, f1d, f2d).ndEach!((v) {
+            v.f1s = cast(float)v.f1;
+            v.f2s = cast(float)v.f2;
+        }, Yes.vectorized);
 
         fxs[] = 0.0f;
         fys[] = 0.0f;
-
-        fxmask[] = cast(ubyte)0;
-        fymask[] = cast(ubyte)0;
+        fxmask[] = ubyte(0);
+        fymask[] = ubyte(0);
 
         // Fill-in masks where points are present
-        foreach(p, r; lockstep(points, searchRegions))
+        foreach (p, r; lockstep(points, searchRegions))
         {
             auto rb = cast(int)(p[0] - r[0] / 2.0f);
             auto re = cast(int)(p[0] + r[0] / 2.0f);
@@ -137,9 +147,9 @@ class LucasKanadeFlow : SparseOpticalFlow
                 continue;
             }
 
-            foreach(i; rb .. re)
+            foreach (i; rb .. re)
             {
-                foreach(j; cb .. ce)
+                foreach (j; cb .. ce)
                 {
                     fxmask[i, j] = cast(ubyte)1;
                     fymask[i, j] = cast(ubyte)1;

--- a/source/dcv/tracking/opticalflow/pyramidflow.d
+++ b/source/dcv/tracking/opticalflow/pyramidflow.d
@@ -245,8 +245,9 @@ class DensePyramidFlow : DenseOpticalFlow
                 current = warp(current, flow);
             }
 
+            import dcv.core.utils : asType;
             // evaluate the flow algorithm
-            auto lflow = flowAlgorithm.evaluate(current.asImage(f1.format), next.asImage(f2.format));
+            auto lflow = flowAlgorithm.evaluate(current.asType!ubyte.asImage(f1.format), next.asType!ubyte.asImage(f2.format));
 
             // add flow calculated in this iteration to previous one.
             flow[] += lflow;


### PR DESCRIPTION
Introducing following changes (should resolve #20):
- added Mir as dependency
- std.experimental.ndslice --> mir.ndslice
- slice.byElement.map/each/reduce/fold --> ndMap/ndEach/ndReduce/ndFold
- reformating of dcv.core.algorithm according to previous changes
- minor refactoring and optimization of library and example code related to dcv.core.algorithm changes

Eventually more algorithm optimizations will follow due to ndslice.algorithm. For this PR I didn't want to go too deep into changes described in #27, since those seemed to be too extensive and off-topic for this PR. So, we'll attend to that in future. 

Pinging @9il @DmitryOlshansky if you're willing to review. 
