### PR TITLE
Mir Refactoring

### DIFF
--- a/examples/features/source/app.d
+++ b/examples/features/source/app.d
@@ -32,7 +32,7 @@ void main()
     auto gray = imfslice.rgb2gray;
 
     // make copies to draw corners 
-    auto pixelSize = imslice.shape.reduce!"a*b";
+    auto pixelSize = imslice.elementsCount;
     auto shiTomasiDraw = new ubyte[pixelSize].sliced(imslice.shape);
     auto harrisDraw = new ubyte[pixelSize].sliced(imslice.shape);
     shiTomasiDraw[] = imslice[];

--- a/examples/filter/source/app.d
+++ b/examples/filter/source/app.d
@@ -54,7 +54,7 @@ int main(string[] args)
     auto bilBlur = imslice.bilateralFilter(10.0f, 5);
 
     // Add salt and pepper noise at input image green channel
-    auto noisyImage = imslice.byElement.array.sliced(imslice.shape);
+    auto noisyImage = imslice.slice;
     auto saltNPepperNoise = noisyImage[0 .. $, 0 .. $, 1].saltNPepper(0.15f);
     // ... and perform median blurring on noisy image
     auto medBlur = noisyImage.medianFilter(5);

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -53,6 +53,9 @@ enum NormType
 /**
 Calculate value of various norm types for vectors and matrices.
 
+Note:
+    Deprecated in favor of mir.blas.l1 functions: amax asum, nrm2.
+
 Params:
     tensor = Tensor of which the norm value is calculated.
     normType = requested type of norm.
@@ -60,7 +63,7 @@ Params:
 Returns:
     Calculated norm value.
 */
-@nogc pure nothrow auto norm(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType)
+deprecated @nogc pure nothrow auto norm(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType)
 {
     import mir.glas.l1;
     final switch (normType)
@@ -130,7 +133,7 @@ Params:
 Returns:
     Returns normalized input tensor.
 */
-@nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
+deprecated @nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
 {
     alias T = DeepElementType!(typeof(tensor));
     auto n = tensor.norm(normType);
@@ -165,7 +168,7 @@ Returns:
     Scaled input tensor.
     
 */
-@nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
+deprecated @nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
         if (isNumeric!Scalar)
 {
     tensor.ndEach!((ref v) { v = alpha * (v) + beta; }, Yes.vectorized);

--- a/source/dcv/core/image.d
+++ b/source/dcv/core/image.d
@@ -542,14 +542,14 @@ Image asImage(size_t N, T)(Slice!(N, T*) slice, ImageFormat format)
 
     static if (N == 2)
     {
-        ubyte* ptr = cast(ubyte*)slice.byElement.array.ptr;
+        ubyte* ptr = cast(ubyte*)slice.slice.ptr;
         ubyte[] s_arr = ptr[0 .. slice.elementsCount * T.sizeof][];
         enforce(format.to!int == 1, "Invalid image format - has to be single channel");
         return new Image(slice.shape[1], slice.shape[0], format, depth, s_arr);
     }
     else static if (N == 3)
     {
-        ubyte* ptr = cast(ubyte*)slice.byElement.array.ptr;
+        ubyte* ptr = cast(ubyte*)slice.slice.ptr;
         ubyte[] s_arr = ptr[0 .. slice.elementsCount * T.sizeof][];
         auto ch = slice.shape[2];
         enforce(ch >= 1 && ch <= 4,

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -188,7 +188,7 @@ Slice!(2, InputType*) conv2Impl(alias bc, InputType, KernelType, MaskType)(Slice
 {
 
     if (prealloc.empty || prealloc.shape != range.shape)
-        prealloc = uninitializedArray!(InputType[])(cast(size_t)range.shape.reduce!"a*b").sliced(range.shape);
+        prealloc = uninitializedArray!(InputType[])(cast(size_t)range.elementsCount).sliced(range.shape);
 
     enforce(&range[0, 0] != &prealloc[0, 0], "Preallocated has to contain different data from that of a input range.");
 
@@ -231,7 +231,7 @@ Slice!(3, InputType*) conv3Impl(alias bc, InputType, KernelType, MaskType, size_
         Slice!(NK, MaskType*) mask)
 {
     if (prealloc.empty || prealloc.shape != range.shape)
-        prealloc = uninitializedArray!(InputType[])(cast(size_t)range.shape.reduce!"a*b").sliced(range.shape);
+        prealloc = uninitializedArray!(InputType[])(cast(size_t)range.elementsCount).sliced(range.shape);
 
     enforce(&range[0, 0, 0] != &prealloc[0, 0, 0],
             "Preallocated has to contain different data from that of a input range.");

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -470,7 +470,7 @@ body
     import std.array : array, uninitializedArray;
     import std.algorithm : equal, reduce;
 
-    auto itemLength = slice.shape.reduce!"a*b";
+    auto itemLength = slice.elementsCount;
     if (!fx.shape[].equal(slice.shape[]))
         fx = uninitializedArray!(V[])(itemLength).sliced(slice.shape);
     if (!fy.shape[].equal(slice.shape[]))
@@ -768,7 +768,7 @@ body
 
     if (prealloc.empty || prealloc.shape != slice.shape)
     {
-        prealloc = uninitializedArray!(OutputType[])(slice.shape.reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(OutputType[])(slice.elementsCount).sliced(slice.shape);
     }
 
     int ks = cast(int)kernelSize;
@@ -832,7 +832,7 @@ Slice!(N, OutputType*) bilateralFilter(alias bc = neumann, InputType, OutputType
 {
     if (prealloc.empty || prealloc.shape != slice.shape)
     {
-        prealloc = uninitializedArray!(OutputType[])(slice.shape.reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(OutputType[])(slice.elementsCount).sliced(slice.shape);
     }
 
     foreach (channel; 0 .. slice.length!2)
@@ -875,7 +875,7 @@ body
     import std.algorithm.iteration : reduce;
 
     if (prealloc.shape != slice.shape)
-        prealloc = uninitializedArray!(O[])(slice.shape.reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(O[])(slice.elementsCount).sliced(slice.shape);
 
     static if (N == 1)
         medianFilterImpl1!BoundaryConditionTest(slice, prealloc, kernelSize);
@@ -1013,7 +1013,7 @@ body
 {
     import std.array : uninitializedArray;
 
-    int n = cast(int)slice.shape.reduce!"a*b"; // number of pixels in image.
+    int n = cast(int)slice.elementsCount; // number of pixels in image.
     immutable tmax = cast(int)T.max; // maximal possible value for pixel value type.
 
     // The probability of an occurrence of a pixel of level i in the image
@@ -1026,7 +1026,7 @@ body
     }
 
     if (prealloc.shape != slice.shape)
-        prealloc = uninitializedArray!(T[])(slice.shape.reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(T[])(slice.elementsCount).sliced(slice.shape);
 
     static if (N == 2)
     {
@@ -1308,7 +1308,7 @@ body
     import std.array : uninitializedArray;
 
     if (prealloc.shape != slice.shape)
-        prealloc = uninitializedArray!(T[])(slice.shape.reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(T[])(slice.elementsCount).sliced(slice.shape);
 
     int rows = cast(int)slice.length!0;
     int cols = cast(int)slice.length!1;

--- a/source/dcv/imgproc/imgmanip.d
+++ b/source/dcv/imgproc/imgmanip.d
@@ -272,7 +272,7 @@ private
         typeof(image) warped;
         if (prealloc.empty || !prealloc.shape.array.equal(image.shape.array))
         {
-            warped = uninitializedArray!(T[])(image.shape.reduce!"a*b").sliced(image.shape);
+            warped = uninitializedArray!(T[])(image.elementsCount).sliced(image.shape);
         }
         else
         {

--- a/source/dcv/imgproc/threshold.d
+++ b/source/dcv/imgproc/threshold.d
@@ -53,7 +53,7 @@ body
 
     if (prealloc.shape[] != slice.shape[])
     {
-        prealloc = uninitializedArray!(OutputType[])(slice.shape[].reduce!"a*b").sliced(slice.shape);
+        prealloc = uninitializedArray!(OutputType[])(slice.elementsCount).sliced(slice.shape);
     }
 
     static if (isFloatingPoint!OutputType)

--- a/source/dcv/io/image.d
+++ b/source/dcv/io/image.d
@@ -180,7 +180,7 @@ bool imwrite(size_t dims, T)(Slice!(dims, T*) slice, ImageFormat format, in stri
 {
     static assert(dims >= 2);
 
-    auto sdata = slice.reshape(slice.shape[].reduce!"a*b").array;
+    auto sdata = slice.reshape(slice.elementsCount).array;
 
     static if (is(T == ubyte))
     {


### PR DESCRIPTION
Following #33 by @9il.

Refactoring:
- tensor.shape.reduce!"a*b" --> tensor.elementsCount
- tensor.byElement.array.sliced(tensor.shape) --> tensor.slice
- @9il anything else you've noticed we could change here?

Deprecation, due to new stuff in Mir 0.17.x:
- norm
- normalized
- scaled
