### PR TITLE
Library sepearation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
-./dcv
-./dub.selections.json
-/dcv
-/dub.selections.json
 .dub/
-*.userprefs
+dub.selections.json
+dub.userprefs
 *.lst
 __test__*
-
-source/.DS_Store
-
-.DS_Store
+libdcv*.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ script:
  - dub build video
  - dub build klt
  - dub build hornschunck
- - dub test dcv:core -b unittest-cov
- - dub test dcv:io -b unittest-cov
- - dub test dcv:plot -b unittest-cov
  - dub test dcv -b unittest-release
+ - dub test dcv:plot -b unittest-cov
+ - dub test dcv:io -b unittest-cov
+ - dub test dcv:core -b unittest-cov
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,7 @@ script:
  - dub test dcv:core -b unittest-cov
  - dub test dcv:io -b unittest-cov
  - dub test dcv:plot -b unittest-cov
- - dub test dcv:core -b unittest-release
- - dub test dcv:io -b unittest-release
- - dub test dcv:plot -b unittest-release
+ - dub test dcv -b unittest-release
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,12 @@ script:
  - dub build video
  - dub build klt
  - dub build hornschunck
- - dub test -b unittest-cov
- - dub test -b unittest-release
+ - dub test dcv:core -b unittest-cov
+ - dub test dcv:io -b unittest-cov
+ - dub test dcv:plot -b unittest-cov
+ - dub test dcv:core -b unittest-release
+ - dub test dcv:io -b unittest-release
+ - dub test dcv:plot -b unittest-release
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,10 @@
         ":plot": "*"
     },
 
+    "subConfigurations": {
+        ":plot": "ggplotd"
+    },
+
     "buildTypes": {
         "unittest-release": {
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
@@ -53,8 +57,20 @@
                 "source/dcv/plot"
             ],
             "dependencies":{
-                "dcv:core": ">=0.0.0",
-                "ggplotd": "~>0.9.4"
+                "dcv:core": ">=0.0.0"
+            },
+            "configurations":
+            {
+                {
+                    "name": "default"
+                },
+                {
+                    "name": "ggplotd",
+                    "dependencies": {
+                        "ggplotd": "~>0.9.4"
+                    },
+                    "versions": ["ggplotd"]
+                }
             },
             "libs": ["gl", "glfw"]
         }

--- a/dub.json
+++ b/dub.json
@@ -29,13 +29,6 @@
                 "source/dcv/multiview",
                 "source/dcv/tracking"
             ],
-            "configurations":
-            [
-                {
-                    "name": "source",
-                    "targetType": "sourceLibrary"
-                }
-            ],
             "dependencies":
             {
                 "mir": "~>0.17.0-alpha9"
@@ -46,13 +39,6 @@
             "description": "Image and Video I/O package.",
             "sourcePaths": [
                 "source/dcv/io"
-            ],
-            "configurations":
-            [
-                {
-                    "name": "source",
-                    "targetType": "sourceLibrary"
-                }
             ],
             "dependencies":{
                 "dcv:core": ">=0.0.0",
@@ -65,13 +51,6 @@
             "description": "Visualization package.",
             "sourcePaths": [
                 "source/dcv/plot"
-            ],
-            "configurations":
-            [
-                {
-                    "name": "source",
-                    "targetType": "sourceLibrary"
-                }
             ],
             "dependencies":{
                 "dcv:core": ">=0.0.0",

--- a/dub.json
+++ b/dub.json
@@ -60,7 +60,7 @@
                 "dcv:core": ">=0.0.0"
             },
             "configurations":
-            {
+            [
                 {
                     "name": "default"
                 },
@@ -71,7 +71,7 @@
                     },
                     "versions": ["ggplotd"]
                 }
-            },
+            ],
             "libs": ["gl", "glfw"]
         }
     ]

--- a/dub.json
+++ b/dub.json
@@ -12,8 +12,12 @@
     },
 
     "subConfigurations": {
-        ":plot": "ggplotd"
+        "dcv:plot": "ggplotd"
     },
+
+    "targetType": "library",
+    "sourcePaths": ["scripts"],
+    "sourceFiles": ["source/dcv/core/image.d"],
 
     "buildTypes": {
         "unittest-release": {

--- a/dub.json
+++ b/dub.json
@@ -11,10 +11,6 @@
         ":plot": "*"
     },
 
-    "subConfigurations": {
-        "dcv:plot": "ggplotd"
-    },
-
     "targetType": "library",
     "sourcePaths": ["scripts"],
     "sourceFiles": ["source/dcv/core/image.d"],
@@ -24,6 +20,19 @@
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
         }
     },
+
+    "configurations": [
+        {
+            "name": "default"
+        },
+        {
+            "name": "ggplotd",
+            "subConfigurations": 
+            {
+                "dcv:plot": "ggplotd"
+            }
+        }
+    ],
 
     "subPackages":
     [

--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,6 @@
 
     "buildTypes": {
         "unittest-release": {
-            "sourcePaths": ["source/"],
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
         }
     },

--- a/dub.json
+++ b/dub.json
@@ -4,22 +4,80 @@
     "copyright": "Copyright © 2016, Relja Ljubobratovic",
     "authors": ["Relja Ljubobratovic"],
     "license": "BSL-1.0",
+
     "dependencies": {
-        "mir": "~>0.17.0-alpha9",
-        "imageformats": "~>6.1.0",
-        "ffmpeg-d": "2.5.0",
-        "ggplotd": "~>0.9.4"
+        ":core": "*",
+        ":io": "*",
+        ":plot": "*"
     },
+
     "buildTypes": {
         "unittest-release": {
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
         }
     },
-    "configurations": [
+
+    "subPackages":
+    [
         {
-            "name": "source",
-            "targetType": "sourceLibrary"
+            "name": "core",
+            "description": "Core package of DCV. Contains computer vision algorithms.",
+            "sourcePaths": [
+                "source/dcv/core",
+                "source/dcv/features",
+                "source/dcv/imgproc",
+                "source/dcv/multiview",
+                "source/dcv/tracking"
+            ],
+            "configurations":
+            [
+                {
+                    "name": "source",
+                    "targetType": "sourceLibrary"
+                }
+            ],
+            "dependencies":
+            {
+                "mir": "~>0.17.0-alpha9"
+            }
+        },
+        {
+            "name": "io",
+            "description": "Image and Video I/O package.",
+            "sourcePaths": [
+                "source/dcv/io"
+            ],
+            "configurations":
+            [
+                {
+                    "name": "source",
+                    "targetType": "sourceLibrary"
+                }
+            ],
+            "dependencies":{
+                "dcv:core": ">=0.0.0",
+                "imageformats": "~>6.1.0",
+                "ffmpeg-d": "~>2.5.1"
+            }
+        },
+        {
+            "name": "plot",
+            "description": "Visualization package.",
+            "sourcePaths": [
+                "source/dcv/plot"
+            ],
+            "configurations":
+            [
+                {
+                    "name": "source",
+                    "targetType": "sourceLibrary"
+                }
+            ],
+            "dependencies":{
+                "dcv:core": ">=0.0.0",
+                "ggplotd": "~>0.9.4"
+            },
+            "libs": ["gl", "glfw"]
         }
-    ],
-    "libs": ["gl", "glfw"]
+    ]
 }

--- a/dub.json
+++ b/dub.json
@@ -12,11 +12,10 @@
     },
 
     "targetType": "library",
-    "sourcePaths": ["scripts"],
-    "sourceFiles": ["source/dcv/core/image.d"],
 
     "buildTypes": {
         "unittest-release": {
+            "sourcePaths": ["source/"],
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]
         }
     },

--- a/examples/features/dub.json
+++ b/examples/features/dub.json
@@ -1,12 +1,16 @@
 {
-	"name": "features",
-	"description": "A minimal D application.",
-	"copyright": "Copyright © 2016, relja",
-	"authors": ["relja"],
-	"dependencies": {
-		"dcv": {
-			"version": "~master",
-			"path": "../../"
-		}
-	}
+    "name": "features",
+    "description": "A minimal D application.",
+    "copyright": "Copyright © 2016, relja",
+    "authors": ["relja"],
+    "dependencies": {
+        "dcv": {
+            "version": "~master",
+            "path": "../../"
+        }
+    },
+    "subConfigurations":
+    {
+        "dcv": "ggplotd"
+    }
 }

--- a/examples/morph/.gitignore
+++ b/examples/morph/.gitignore
@@ -5,3 +5,4 @@ __dummy.html
 *.obj
 /filter
 *.selections.json
+morph

--- a/examples/tracking/hornschunck/.gitignore
+++ b/examples/tracking/hornschunck/.gitignore
@@ -1,2 +1,3 @@
 /dub.selections.json
 
+hornschunck

--- a/examples/tracking/klt/dub.json
+++ b/examples/tracking/klt/dub.json
@@ -1,12 +1,16 @@
 {
-	"name": "klt",
-	"description": "A minimal D application.",
-	"copyright": "Copyright © 2016, relja",
-	"authors": ["relja"],
-	"dependencies": {
-		"dcv": {
-			"version": "~master",
-			"path": "../../../"
-		}
-	}
+    "name": "klt",
+    "description": "A minimal D application.",
+    "copyright": "Copyright © 2016, relja",
+    "authors": ["relja"],
+    "dependencies": {
+        "dcv": {
+            "version": "~master",
+            "path": "../../../"
+        }
+    },
+    "subConfigurations":
+    {
+        "dcv": "ggplotd"
+    }
 }

--- a/source/dcv/multiview/package.d
+++ b/source/dcv/multiview/package.d
@@ -1,0 +1,1 @@
+module dcv.multiview;

--- a/source/dcv/package.d
+++ b/source/dcv/package.d
@@ -1,0 +1,12 @@
+module dcv;
+
+public 
+{
+    import dcv.core;
+    import dcv.features;
+    import dcv.imgproc;
+    import dcv.multiview;
+    import dcv.tracking;
+    import dcv.io;
+    import dcv.plot;
+}

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -84,7 +84,10 @@ import std.conv : to;
 
 import mir.ndslice;
 
-import ggplotd.ggplotd, ggplotd.aes, ggplotd.axes, ggplotd.geom;
+version(ggplotd)
+{
+    import ggplotd.ggplotd, ggplotd.aes, ggplotd.axes, ggplotd.geom;
+}
 
 import dcv.core.image : Image, ImageFormat, BitDepth, asImage;
 import dcv.core.utils : asType;
@@ -168,59 +171,62 @@ Figure imshow(size_t N, T)(Slice!(N, T*) slice, ImageFormat format, string title
     return f;
 }
 
-/**
-Show given image, and then plot given GGPlotD context on top of it.
-*/
-Figure plot(Image image, GGPlotD gg, string title = "")
+version(ggplotd)
 {
-    auto f = figure(title);
-    f.draw(image);
-    f.draw(gg);
-    f.show();
-    return f;
-}
+    /**
+      Show given image, and then plot given GGPlotD context on top of it.
+     */
+    Figure plot(Image image, GGPlotD gg, string title = "")
+    {
+        auto f = figure(title);
+        f.draw(image);
+        f.draw(gg);
+        f.show();
+        return f;
+    }
 
-/// ditto
-Figure plot(size_t N, T)(Slice!(N, T*) slice, GGPlotD gg, string title = "")
-{
-    auto f = figure(title);
-    f.draw(slice, ImageFormat.IF_UNASSIGNED);
-    f.draw(gg);
-    f.show();
-    return f;
-}
+    /// ditto
+    Figure plot(size_t N, T)(Slice!(N, T*) slice, GGPlotD gg, string title = "")
+    {
+        auto f = figure(title);
+        f.draw(slice, ImageFormat.IF_UNASSIGNED);
+        f.draw(gg);
+        f.show();
+        return f;
+    }
 
-/// ditto
-Figure plot(size_t N, T)(Slice!(N, T*) slice, ImageFormat format, GGPlotD gg, string title = "")
-{
-    auto f = figure(title);
-    f.draw(slice, format);
-    f.draw(gg);
-    f.show();
-    return f;
-}
+    /// ditto
+    Figure plot(size_t N, T)(Slice!(N, T*) slice, ImageFormat format, GGPlotD gg, string title = "")
+    {
+        auto f = figure(title);
+        f.draw(slice, format);
+        f.draw(gg);
+        f.show();
+        return f;
+    }
 
-/**
-Plot GGPlotD context onto figure with given title.
+    /**
+      Plot GGPlotD context onto figure with given title.
 
-Given plot is drawn on top of figure's current image buffer. Size of the figure, and it's image buffer is
-unchanged. If no figure exists with given title, new one is allocated with default setup (500x500, with 
-black background), and the plot is drawn on it.
+      Given plot is drawn on top of figure's current image buffer. Size of the figure, and it's image buffer is
+      unchanged. If no figure exists with given title, new one is allocated with default setup (500x500, with 
+      black background), and the plot is drawn on it.
 
-Params:
-    gg = GGPlotD context, to be plotted on figure.
-    title = Title of the window. If none given (default), window is named by "Figure id".
+     Params:
+         gg = GGPlotD context, to be plotted on figure.
+         title = Title of the window. If none given (default), window is named by "Figure id".
 
-Returns:
-    If figure with given title exists already, that figure is returned, 
-    otherwise new figure is created and returned.
-*/
-Figure plot(GGPlotD gg, string title = "")
-{
-    auto f = figure(title);
-    f.draw(gg);
-    f.show();
-    return f;
+     Returns:
+         If figure with given title exists already, that figure is returned, 
+         otherwise new figure is created and returned.
+     */
+    Figure plot(GGPlotD gg, string title = "")
+    {
+        auto f = figure(title);
+        f.draw(gg);
+        f.show();
+        return f;
+    }
 }
 /**
 Run the event loop for each present figure, and wait for key and/or given time.
@@ -599,6 +605,7 @@ class Figure
             draw(showSlice.asImage(format));
     }
 
+
     /**
     Draw the GGPlotD context on this figure's canvas.
 
@@ -609,7 +616,7 @@ class Figure
         - GGPlotD's margins are zeroed out in this function, and axes hidden.
         - GGPlotD's axes ranges are configured in this function to match figure size (width and height).
     */
-    void draw(GGPlotD plot)
+    version(ggplotd) void draw(GGPlotD plot)
     {
         drawGGPlotD(plot, _data, _width, _height);
         fitWindow();
@@ -884,7 +891,7 @@ Image adoptImage(Image image)
     return showImage;
 }
 
-void drawGGPlotD(GGPlotD gg,  ubyte[] data,  int width, int height)
+version(ggplotd) void drawGGPlotD(GGPlotD gg,  ubyte[] data,  int width, int height)
 {
     import std.parallelism : parallel;
     import std.range : iota;


### PR DESCRIPTION
Working on #25.
## Library separated to following subPackages:
- core: core of the DCV, computer vision algorithms;
- io: image and video I/O;
- plot: visualization package.
## Main motivation:
- have modular library setup, and by that less dependencies for core module;
- having core module not depend on C libraries.
- ... there were more, can't remember at the moment..
## SubPackage dependencies:
- core
  - [mir](https://github.com/libmir/mir)
- io
  - core
  - [imageformats](https://github.com/lgvz/imageformats)
  - [ffmpeg-d](https://github.com/ljubobratovicrelja/ffmpeg-d)
- plot
  - core
  - [ggplotd](https://github.com/BlackEdder/ggplotd) (optional)
## Configurations:

To make ggplotd optional, [_ggplotd_](https://github.com/ljubobratovicrelja/dcv/blob/library-sepearation/dub.json#L81-L85) configuration has been added to dcv:plot package. And to make it optional on the global level, [_ggplotd_](https://github.com/ljubobratovicrelja/dcv/blob/library-sepearation/dub.json#L28-L34) configuration has been added to root package. So to use ggplotd stuff, `subConfiguration` has to be defined, like in some of the [examples](https://github.com/ljubobratovicrelja/dcv/blob/library-sepearation/examples/features/dub.json#L12-L15).

---

Pinging @DmitryOlshansky @9il @henrygouk all of you, since I feel this is a big change, and I'd like all of you to review it, and tell me what you think. 

**Note**: ggplotd configuration's name is not so lucky in mu opinion, but I'm not sure how better to name it. If anyone has a suggestion, fire away. 

One more **note**: There seam to be a bug in Dub in making this kind of setup. When setting up sub-packages like this, unittest-cov build gets messed up. This is actually copied from vibe.d's dub config as example, and there they offer a [workaround](https://github.com/rejectedsoftware/vibe.d/blob/master/dub.sdl#L23-L27). This is also applied [here](https://github.com/ljubobratovicrelja/dcv/blob/library-sepearation/dub.json#L15-L16), and seems to be working like a charm (until proven otherwise...).

---

Closes #25 
