### PR TITLE
Optional parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
  - linux
 
 d:
- - dmd-2.071.1
  - ldc-1.1.0-beta2
 
 addons:

--- a/examples/imgmanip/source/app.d
+++ b/examples/imgmanip/source/app.d
@@ -34,14 +34,14 @@ void main()
 
     // resize 1D array:
     writeln("1D:");
-    array_1d.resize(9).writeln; // so, same as calling array_1d.resize!linear(9)
+    array_1d.resize([9]).writeln; // so, same as calling array_1d.resize!linear([9])
     writeln();
 
     auto array_2d = [1., 2., 3., 4.].sliced(2, 2);
 
     // resize 2D array:
     writeln("2D:");
-    auto res_2d = array_2d.resize(9, 9);
+    auto res_2d = array_2d.resize([9, 9]);
     foreach (row; res_2d)
         row.writeln;
     writeln();
@@ -50,18 +50,18 @@ void main()
 
     // resize 3D array:
     writeln("3D:");
-    auto res_3d = array_3d.resize(9, 9);
+    auto res_3d = array_3d.resize([9, 9]);
     foreach (row; res_3d)
         row.writeln;
     writeln();
 
     // resize image:
     auto image = [255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255].sliced(2, 2, 3).asType!ubyte;
-    auto resizedImage = image.resize(300, 300);
+    auto resizedImage = image.resize([300, 300]);
     resizedImage.imwrite(ImageFormat.IF_RGB, "./result/resizedImage.png");
 
     // scale image:
-    auto scaledImage = resizedImage.scale(2., 2.);
+    auto scaledImage = resizedImage.scale([2., 2.]);
     scaledImage.imwrite(ImageFormat.IF_RGB, "./result/scaledImage.png");
 
     /*

--- a/source/dcv/imgproc/color.d
+++ b/source/dcv/imgproc/color.d
@@ -42,7 +42,6 @@ import std.algorithm.mutation : copy;
 import std.algorithm.comparison : equal;
 import std.algorithm : swap;
 import std.range : zip, array, iota;
-import std.parallelism : parallel;
 import std.exception : enforce;
 import std.range : lockstep;
 

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -75,6 +75,7 @@ Params:
     prealloc is not of same shape as input range, resulting array will be newly allocated. 
     mask = Masking range. Convolution will skip each element where mask is 0. Default value
     is empty slice, which tells that convolution will be performed on the whole range.
+    pool = Optional TaskPool instance used to parallelize computation.
 
 Returns:
     Slice of resulting image after convolution.

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -51,7 +51,7 @@ import std.algorithm.comparison : equal;
 import std.algorithm.iteration : reduce;
 import std.algorithm.comparison : max, min;
 import std.exception : enforce;
-import std.parallelism : parallel;
+import std.parallelism : parallel, taskPool, TaskPool;
 import std.math : abs, floor;
 
 import mir.ndslice;
@@ -81,7 +81,7 @@ Returns:
 */
 Slice!(N, InputType*) conv(alias bc = neumann, InputType, KernelType, MaskType = InputType, size_t N, size_t NK)(Slice!(N,
         InputType*) range, Slice!(NK, KernelType*) kernel, Slice!(N,
-        InputType*) prealloc = emptySlice!(N, InputType), Slice!(NK, MaskType*) mask = emptySlice!(NK, MaskType))
+        InputType*) prealloc = emptySlice!(N, InputType), Slice!(NK, MaskType*) mask = emptySlice!(NK, MaskType), TaskPool pool = taskPool)
 {
     static assert(isBoundaryCondition!bc, "Invalid boundary condition test function.");
     static assert(isAssignable!(InputType, KernelType), "Uncompatible types for range and kernel");
@@ -97,17 +97,17 @@ Slice!(N, InputType*) conv(alias bc = neumann, InputType, KernelType, MaskType =
     static if (N == 1)
     {
         static assert(NK == 1, "Invalid kernel dimension");
-        return conv1Impl!bc(range, kernel, prealloc, mask);
+        return conv1Impl!bc(range, kernel, prealloc, mask, pool);
     }
     else static if (N == 2)
     {
         static assert(NK == 2, "Invalid kernel dimension");
-        return conv2Impl!bc(range, kernel, prealloc, mask);
+        return conv2Impl!bc(range, kernel, prealloc, mask, pool);
     }
     else static if (N == 3)
     {
         static assert(NK == 2, "Invalid kernel dimension");
-        return conv3Impl!bc(range, kernel, prealloc, mask);
+        return conv3Impl!bc(range, kernel, prealloc, mask, pool);
     }
     else
     {
@@ -151,7 +151,7 @@ private:
 
 // TODO: implement SIMD
 Slice!(1, InputType*) conv1Impl(alias bc, InputType, KernelType, MaskType)(Slice!(1, InputType*) range,
-        Slice!(1, KernelType*) kernel, Slice!(1, InputType*) prealloc, Slice!(1, MaskType*) mask)
+        Slice!(1, KernelType*) kernel, Slice!(1, InputType*) prealloc, Slice!(1, MaskType*) mask, TaskPool pool)
 {
 
     if (prealloc.empty || prealloc.shape != range.shape)
@@ -168,7 +168,7 @@ Slice!(1, InputType*) conv1Impl(alias bc, InputType, KernelType, MaskType)(Slice
     bool useMask = !mask.empty;
 
     // run main (inner) loop
-    foreach (i; iota(rl).parallel)
+    foreach (i; pool.parallel(iota(rl)))
     {
         if (useMask && !mask[i])
             continue;
@@ -184,7 +184,7 @@ Slice!(1, InputType*) conv1Impl(alias bc, InputType, KernelType, MaskType)(Slice
 }
 
 Slice!(2, InputType*) conv2Impl(alias bc, InputType, KernelType, MaskType)(Slice!(2, InputType*) range,
-        Slice!(2, KernelType*) kernel, Slice!(2, InputType*) prealloc, Slice!(2, MaskType*) mask)
+        Slice!(2, KernelType*) kernel, Slice!(2, InputType*) prealloc, Slice!(2, MaskType*) mask, TaskPool pool)
 {
 
     if (prealloc.empty || prealloc.shape != range.shape)
@@ -204,7 +204,7 @@ Slice!(2, InputType*) conv2Impl(alias bc, InputType, KernelType, MaskType)(Slice
     bool useMask = !mask.empty;
 
     // run inner body convolution of the matrix.
-    foreach (i; iota(rr).parallel)
+    foreach (i; pool.parallel(iota(rr)))
     {
         auto row = prealloc[i, 0 .. rc];
         foreach (j; iota(rc))
@@ -228,7 +228,7 @@ Slice!(2, InputType*) conv2Impl(alias bc, InputType, KernelType, MaskType)(Slice
 
 Slice!(3, InputType*) conv3Impl(alias bc, InputType, KernelType, MaskType, size_t NK)(Slice!(3,
         InputType*) range, Slice!(NK, KernelType*) kernel, Slice!(3, InputType*) prealloc,
-        Slice!(NK, MaskType*) mask)
+        Slice!(NK, MaskType*) mask, TaskPool pool)
 {
     if (prealloc.empty || prealloc.shape != range.shape)
         prealloc = uninitializedArray!(InputType[])(cast(size_t)range.elementsCount).sliced(range.shape);
@@ -240,7 +240,7 @@ Slice!(3, InputType*) conv3Impl(alias bc, InputType, KernelType, MaskType, size_
     {
         auto r_c = range[0 .. $, 0 .. $, i];
         auto p_c = prealloc[0 .. $, 0 .. $, i];
-        r_c.conv(kernel, p_c);
+        r_c.conv(kernel, p_c, mask, pool);
     }
 
     return prealloc;

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -744,8 +744,8 @@ Params:
     slice = Slice of the input image.
     sigma = Smoothing strength parameter.
     kernelSize = Size of convolution kernel. Must be odd number.
-    prealloc = Optional pre-allocated result image buffer. If not of same shape as input slice, its allocated
-        anew.
+    prealloc = Optional pre-allocated result image buffer. If not of same shape as input slice, its allocated anew.
+    pool = Optional TaskPool instance used to parallelize computation.
 
 Returns:
     Slice of filtered image.
@@ -851,6 +851,7 @@ Params:
     slice = Input image slice.
     kernelSize = Square size of median kernel.
     prealloc = Optional pre-allocated return image buffer.
+    pool = Optional TaskPool instance used to parallelize computation.
 
 Returns:
     Returns filtered image of same size as the input. If prealloc parameter is not an empty slice, and is
@@ -1101,6 +1102,7 @@ Params:
     slice = Input image slice, to be eroded.
     kernel = Erosion kernel. Default value is radialKernel!T(3).
     prealloc = Optional pre-allocated buffer to hold result.
+    pool = Optional TaskPool instance used to parallelize computation.
     
 Returns:
     Eroded image slice, of same type as input image.
@@ -1161,6 +1163,7 @@ Params:
     slice = Input image slice, to be eroded.
     kernel = Dilation kernel. Default value is radialKernel!T(3).
     prealloc = Optional pre-allocated buffer to hold result.
+    pool = Optional TaskPool instance used to parallelize computation.
     
 Returns:
     Dilated image slice, of same type as input image.
@@ -1185,6 +1188,7 @@ Params:
     slice = Input image slice, to be eroded.
     kernel = Erosion/Dilation kernel. Default value is radialKernel!T(3).
     prealloc = Optional pre-allocated buffer to hold result.
+    pool = Optional TaskPool instance used to parallelize computation.
     
 Returns:
     Opened image slice, of same type as input image.
@@ -1210,6 +1214,7 @@ Params:
     slice = Input image slice, to be eroded.
     kernel = Erosion/Dilation kernel. Default value is radialKernel!T(3).
     prealloc = Optional pre-allocated buffer to hold result.
+    pool = Optional TaskPool instance used to parallelize computation.
     
 Returns:
     Closed image slice, of same type as input image.

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -51,7 +51,7 @@ import std.algorithm.sorting : topN;
 import std.algorithm.comparison : max;
 import std.algorithm.mutation : copy;
 import std.array : uninitializedArray;
-import std.parallelism : parallel, taskPool;
+import std.parallelism : parallel, taskPool, TaskPool;
 
 import dcv.core.algorithm;
 import dcv.core.utils;
@@ -752,7 +752,7 @@ Returns:
 */
 Slice!(N, OutputType*) bilateralFilter(alias bc = neumann, InputType, OutputType = InputType, size_t N)(Slice!(N,
         InputType*) slice, float sigma, uint kernelSize, Slice!(N,
-        OutputType*) prealloc = emptySlice!(N, OutputType)) if (N == 2)
+        OutputType*) prealloc = emptySlice!(N, OutputType), TaskPool pool = taskPool) if (N == 2)
 in
 {
     static assert(isBoundaryCondition!bc, "Invalid boundary condition test function.");
@@ -764,7 +764,7 @@ body
     import std.algorithm.comparison : max;
     import std.algorithm.iteration : reduce;
     import std.math : exp, sqrt;
-    import std.parallelism : parallel;
+    import mir.glas.l1 : asum;
 
     if (prealloc.empty || prealloc.shape != slice.shape)
     {
@@ -776,7 +776,7 @@ body
     int rows = cast(int)slice.length!0;
     int cols = cast(int)slice.length!1;
 
-    foreach (r; iota(rows).parallel)
+    foreach (r; pool.parallel(iota(rows)))
     {
         auto mask = new float[ks * ks].sliced(ks, ks);
         foreach (c; 0 .. cols)
@@ -802,7 +802,7 @@ body
             }
 
             // normalize mask and calculate result value.
-            float mask_sum = mask.norm(NormType.L1);
+            float mask_sum = mask.asum;
             float res_val = 0.0f;
 
             i = 0;
@@ -858,7 +858,7 @@ Returns:
     is used.
 */
 Slice!(N, O*) medianFilter(alias BoundaryConditionTest = neumann, T, O = T, size_t N)(Slice!(N,
-        T*) slice, size_t kernelSize, Slice!(N, O*) prealloc = emptySlice!(N, O))
+        T*) slice, size_t kernelSize, Slice!(N, O*) prealloc = emptySlice!(N, O), TaskPool pool = taskPool)
 in
 {
     import std.traits : isAssignable;
@@ -878,13 +878,15 @@ body
         prealloc = uninitializedArray!(O[])(slice.elementsCount).sliced(slice.shape);
 
     static if (N == 1)
-        medianFilterImpl1!BoundaryConditionTest(slice, prealloc, kernelSize);
+        alias medianFilterImpl = medianFilterImpl1;
     else static if (N == 2)
-        medianFilterImpl2!BoundaryConditionTest(slice, prealloc, kernelSize);
+        alias medianFilterImpl = medianFilterImpl2;
     else static if (N == 3)
-        medianFilterImpl3!BoundaryConditionTest(slice, prealloc, kernelSize);
+        alias medianFilterImpl = medianFilterImpl3;
     else
         static assert(0, "Invalid slice dimension for median filtering.");
+
+    medianFilterImpl!BoundaryConditionTest(slice, prealloc, kernelSize, pool);
 
     return prealloc;
 }
@@ -1104,10 +1106,11 @@ Returns:
     Eroded image slice, of same type as input image.
 */
 Slice!(2, T*) erode(alias BoundaryConditionTest = neumann, T)(Slice!(2, T*) slice,
-        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T))
+        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T),
+    TaskPool pool = taskPool)
         if (isBoundaryCondition!BoundaryConditionTest)
 {
-    return morphOp!(MorphologicOperation.ERODE, BoundaryConditionTest)(slice, kernel, prealloc);
+    return morphOp!(MorphologicOperation.ERODE, BoundaryConditionTest)(slice, kernel, prealloc, pool);
 }
 
 /**
@@ -1163,10 +1166,11 @@ Returns:
     Dilated image slice, of same type as input image.
 */
 Slice!(2, T*) dilate(alias BoundaryConditionTest = neumann, T)(Slice!(2, T*) slice,
-        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T))
+        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T),
+    TaskPool pool = taskPool)
         if (isBoundaryCondition!BoundaryConditionTest)
 {
-    return morphOp!(MorphologicOperation.DILATE, BoundaryConditionTest)(slice, kernel, prealloc);
+    return morphOp!(MorphologicOperation.DILATE, BoundaryConditionTest)(slice, kernel, prealloc, pool);
 }
 
 /**
@@ -1186,11 +1190,12 @@ Returns:
     Opened image slice, of same type as input image.
 */
 Slice!(2, T*) open(alias BoundaryConditionTest = neumann, T)(Slice!(2, T*) slice,
-        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T))
+        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T),
+    TaskPool pool = taskPool)
         if (isBoundaryCondition!BoundaryConditionTest)
 {
     return morphOp!(MorphologicOperation.DILATE, BoundaryConditionTest)(morphOp!(MorphologicOperation.ERODE,
-            BoundaryConditionTest)(slice, kernel), kernel, prealloc);
+            BoundaryConditionTest)(slice, kernel, emptySlice!(2, T), pool), kernel, prealloc, pool);
 }
 
 /**
@@ -1210,16 +1215,18 @@ Returns:
     Closed image slice, of same type as input image.
 */
 Slice!(2, T*) close(alias BoundaryConditionTest = neumann, T)(Slice!(2, T*) slice,
-        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T))
+        Slice!(2, T*) kernel = radialKernel!T(3), Slice!(2, T*) prealloc = emptySlice!(2, T),
+    TaskPool pool = taskPool)
         if (isBoundaryCondition!BoundaryConditionTest)
 {
     return morphOp!(MorphologicOperation.ERODE, BoundaryConditionTest)(morphOp!(MorphologicOperation.DILATE,
-            BoundaryConditionTest)(slice, kernel), kernel, prealloc);
+            BoundaryConditionTest)(slice, kernel, emptySlice!(2, T), pool), kernel, prealloc, pool);
 }
 
 private:
 
-void medianFilterImpl1(alias bc, T, O)(Slice!(1, T*) slice, Slice!(1, O*) filtered, size_t kernelSize)
+void medianFilterImpl1(alias bc, T, O)(Slice!(1, T*) slice, Slice!(1, O*) filtered,
+    size_t kernelSize, TaskPool pool)
 {
     import std.algorithm.sorting : topN;
     import std.algorithm.comparison : max;
@@ -1228,9 +1235,9 @@ void medianFilterImpl1(alias bc, T, O)(Slice!(1, T*) slice, Slice!(1, O*) filter
     int kh = max(1, cast(int)kernelSize / 2);
     int length = cast(int)slice.length!0;
 
-    auto kernelStorage = taskPool.workerLocalStorage(new T[kernelSize]);
+    auto kernelStorage = pool.workerLocalStorage(new T[kernelSize]);
 
-    foreach (i; iota(length).parallel)
+    foreach (i; pool.parallel(iota(length)))
     {
         auto kernel = kernelStorage.get();
         size_t ki = 0;
@@ -1243,7 +1250,8 @@ void medianFilterImpl1(alias bc, T, O)(Slice!(1, T*) slice, Slice!(1, O*) filter
     }
 }
 
-void medianFilterImpl2(alias bc, T, O)(Slice!(2, T*) slice, Slice!(2, O*) filtered, size_t kernelSize)
+void medianFilterImpl2(alias bc, T, O)(Slice!(2, T*) slice, Slice!(2, O*) filtered,
+    size_t kernelSize, TaskPool pool)
 {
     int kh = max(1, cast(int)kernelSize / 2);
     int n = cast(int)kernelSize ^^ 2;
@@ -1251,9 +1259,9 @@ void medianFilterImpl2(alias bc, T, O)(Slice!(2, T*) slice, Slice!(2, O*) filter
     int rows = cast(int)slice.length!0;
     int cols = cast(int)slice.length!1;
 
-    auto kernelStorage = taskPool.workerLocalStorage(new T[kernelSize ^^ 2]);
+    auto kernelStorage = pool.workerLocalStorage(new T[kernelSize ^^ 2]);
 
-    foreach (r; iota(rows).parallel)
+    foreach (r; pool.parallel(iota(rows)))
     {
         foreach (c; 0 .. cols)
         {
@@ -1272,11 +1280,12 @@ void medianFilterImpl2(alias bc, T, O)(Slice!(2, T*) slice, Slice!(2, O*) filter
     }
 }
 
-void medianFilterImpl3(alias bc, T, O)(Slice!(3, T*) slice, Slice!(3, O*) filtered, size_t kernelSize)
+void medianFilterImpl3(alias bc, T, O)(Slice!(3, T*) slice, Slice!(3, O*) filtered,
+    size_t kernelSize, TaskPool pool)
 {
     foreach (channel; 0 .. slice.length!2)
     {
-        medianFilterImpl2!bc(slice[0 .. $, 0 .. $, channel], filtered[0 .. $, 0 .. $, channel], kernelSize);
+        medianFilterImpl2!bc(slice[0 .. $, 0 .. $, channel], filtered[0 .. $, 0 .. $, channel], kernelSize, pool);
     }
 }
 
@@ -1297,8 +1306,8 @@ enum MorphologicOperation
 }
 
 Slice!(2, T*) morphOp(MorphologicOperation op, alias BoundaryConditionTest = neumann, T)
-    (Slice!(2, T*) slice, Slice!(2, T*) kernel = radialKernel!T(3), 
-     Slice!(2, T*) prealloc = emptySlice!(2, T)) if (isBoundaryCondition!BoundaryConditionTest)
+    (Slice!(2, T*) slice, Slice!(2, T*) kernel, 
+     Slice!(2, T*) prealloc, TaskPool pool) if (isBoundaryCondition!BoundaryConditionTest)
 in
 {
     assert(!slice.empty);
@@ -1333,7 +1342,7 @@ body
             T value = cast(T)1.0;
     }
 
-    foreach (r; iota(rows).parallel)
+    foreach (r; pool.parallel(iota(rows)))
     {
         foreach (c; 0 .. cols)
         {

--- a/source/dcv/imgproc/imgmanip.d
+++ b/source/dcv/imgproc/imgmanip.d
@@ -53,22 +53,22 @@ Params:
 
 TODO: consider size input as array, and add prealloc
 */
-Slice!(N, V*) resize(alias interp = linear, V, size_t N)(Slice!(N, V*) slice, size_t[] newsize, TaskPool pool = taskPool)
+Slice!(N, V*) resize(alias interp = linear, V, size_t N, size_t SN)(Slice!(N, V*) slice, size_t[SN] newsize, TaskPool pool = taskPool)
         if (isInterpolationFunc!interp)
 {
     static if (N == 1)
     {
-        assert(newsize.length == 1, "Invalid new-size setup - dimension does not match with input slice.");
+        static assert(SN == 1, "Invalid new-size setup - dimension does not match with input slice.");
         return resizeImpl_1!interp(slice, newsize[0], pool);
     }
     else static if (N == 2)
     {
-        assert(newsize.length == 2, "Invalid new-size setup - dimension does not match with input slice.");
+        static assert(SN == 2, "Invalid new-size setup - dimension does not match with input slice.");
         return resizeImpl_2!interp(slice, newsize[0], newsize[1], pool);
     }
     else static if (N == 3)
     {
-        assert(newsize.length == 2, "Invalid new-size setup - 3D resize is performed as 2D."); // TODO: find better way to say this...
+        static assert(SN == 2, "Invalid new-size setup - 3D resize is performed as 2D."); // TODO: find better way to say this...
         return resizeImpl_3!interp(slice, newsize[0], newsize[1], pool);
     }
     else
@@ -106,7 +106,7 @@ using scaled shape of the input slice as:
 $(D_CODE scaled = resize(input, input.shape*scale))
 
  */
-Slice!(N, V*) scale(alias interp = linear, V, size_t N, ScaleValue)(Slice!(N, V*) slice, ScaleValue[] scale, TaskPool pool = taskPool)
+Slice!(N, V*) scale(alias interp = linear, V, ScaleValue, size_t N, size_t SN)(Slice!(N, V*) slice, ScaleValue[SN] scale, TaskPool pool = taskPool)
         if (isFloatingPoint!ScaleValue && isInterpolationFunc!interp)
 {
     foreach (v; scale)
@@ -114,21 +114,21 @@ Slice!(N, V*) scale(alias interp = linear, V, size_t N, ScaleValue)(Slice!(N, V*
 
     static if (N == 1)
     {
-        assert(scale.length == 1, "Invalid scale setup - dimension does not match with input slice.");
+        static assert(SN == 1, "Invalid scale setup - dimension does not match with input slice.");
         size_t newsize = cast(size_t)(slice.length * scale[0]);
         enforce(newsize > 0, "Scaling value invalid - after scaling array size is zero.");
         return resizeImpl_1!interp(slice, newsize, pool);
     }
     else static if (N == 2)
     {
-        assert(scale.length == 2, "Invalid scale setup - dimension does not match with input slice.");
+        static assert(SN == 2, "Invalid scale setup - dimension does not match with input slice.");
         size_t [2]newsize = [cast(size_t)(slice.length!0 * scale[0]), cast(size_t)(slice.length!1 * scale[1])];
         enforce(newsize[0] > 0 && newsize[1] > 0, "Scaling value invalid - after scaling array size is zero.");
         return resizeImpl_2!interp(slice, newsize[0], newsize[1], pool);
     }
     else static if (N == 3)
     {
-        assert(scale.length == 2, "Invalid scale setup - 3D scale is performed as 2D."); // TODO: find better way to say this...
+        static assert(SN == 2, "Invalid scale setup - 3D scale is performed as 2D."); // TODO: find better way to say this...
         size_t [2]newsize = [cast(size_t)(slice.length!0 * scale[0]), cast(size_t)(slice.length!1 * scale[1])];
         enforce(newsize[0] > 0 && newsize[1] > 0, "Scaling value invalid - after scaling array size is zero.");
         return resizeImpl_3!interp(slice, newsize[0], newsize[1], pool);

--- a/source/dcv/imgproc/imgmanip.d
+++ b/source/dcv/imgproc/imgmanip.d
@@ -50,6 +50,7 @@ Params:
     newsize = tuple that defines new shape. New dimension has to be
     the same as input slice in the 1D and 2D resize, where in the 
     3D resize newsize has to be 2D.
+    pool = Optional TaskPool instance used to parallelize computation.
 
 TODO: consider size input as array, and add prealloc
 */

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -913,7 +913,6 @@ Image adoptImage(Image image)
 
 version(ggplotd) void drawGGPlotD(GGPlotD gg,  ubyte[] data,  int width, int height)
 {
-    import std.parallelism : parallel;
     import std.range : iota;
     import cairo = cairo;
 

--- a/source/dcv/tracking/opticalflow/pyramidflow.d
+++ b/source/dcv/tracking/opticalflow/pyramidflow.d
@@ -119,8 +119,8 @@ class SparsePyramidFlow : SparseOpticalFlow
 
             if (lh != h || lw != w)
             {
-                current = f1s.resize(lh, lw);
-                next = f2s.resize(lh, lw);
+                current = f1s.resize([lh, lw]);
+                next = f2s.resize([lh, lw]);
             }
             else
             {
@@ -199,7 +199,7 @@ class DensePyramidFlow : DenseOpticalFlow
         // allocate flow for each pyramid level
         if (usePrevious)
         {
-            flow = prealloc.resize(flowPyramid[0][0], flowPyramid[0][1]);
+            flow = prealloc.resize(flowPyramid[0]);
         }
         else
         {
@@ -228,8 +228,8 @@ class DensePyramidFlow : DenseOpticalFlow
 
             if (lh != h || lw != w)
             {
-                current = f1s.resize(lh, lw);
-                next = f2s.resize(lh, lw);
+                current = f1s.resize([lh, lw]);
+                next = f2s.resize([lh, lw]);
             }
             else
             {
@@ -254,7 +254,7 @@ class DensePyramidFlow : DenseOpticalFlow
 
             if (i < levelCount - 1)
             {
-                flow = flow.resize(flowPyramid[i + 1][0], flowPyramid[i + 1][1]);
+                flow = flow.resize(flowPyramid[i + 1]);
                 flow[] *= 2.0f;
             }
             // assign the first flow indicator to false.


### PR DESCRIPTION
Working on #28.
- added `std.parallelism.TaskPool` as last parameter in each function that utilizes `std.parallelism.parallel`, and added `std.parallelism.taskPool` as default value.
- `dcv.imgproc.imgmanip.resize` and `dcv.imgproc.imgmanip.scale` API change - to allow `TaskPool` as last parameter, target tensor size parameters changed from variadic parameters to static array. 
- Minor trivial changes along the way - (e.g. replacement of deprecated members to their alternatives)

ping @9il and @DmitryOlshansky for review.  
