### PR TITLE
Deprecated vebosity

### DIFF
--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -134,7 +134,7 @@ Params:
 Returns:
     Returns normalized input tensor.
 */
-deprecated("Used array based division: tensor[] /= norm, or mir.ndslice.algorithm: tensor.ndEach!(v => v /= norm)")
+deprecated("Use array based division: tensor[] /= norm, or mir.ndslice.algorithm: tensor.ndEach!(v => v /= norm)")
 @nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
 {
     alias T = DeepElementType!(typeof(tensor));

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -134,7 +134,7 @@ Params:
 Returns:
     Returns normalized input tensor.
 */
-deprecated("Use array based division: tensor[] /= norm, or mir.ndslice.algorithm: tensor.ndEach!(v => v /= norm)")
+deprecated("Use array based division: tensor[] /= norm, or mir.ndslice.algorithm: tensor.ndEach!( (ref v) { v /= norm; } )")
 @nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
 {
     alias T = DeepElementType!(typeof(tensor));
@@ -170,7 +170,6 @@ Returns:
     Scaled input tensor.
     
 */
-deprecated("Function will be moved to Mir")
 @nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
         if (isNumeric!Scalar)
 {
@@ -199,7 +198,6 @@ Params:
     maxValue = Maximal value output tensor should contain.
 
 */
-deprecated("Function will be moved to Mir")
 @nogc auto ranged(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor,
         Scalar minValue = 0, Scalar maxValue = 1) if (isNumeric!Scalar)
 {

--- a/source/dcv/core/algorithm.d
+++ b/source/dcv/core/algorithm.d
@@ -63,7 +63,8 @@ Params:
 Returns:
     Calculated norm value.
 */
-deprecated @nogc pure nothrow auto norm(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType)
+deprecated("Use mir.glas.l1 functions: amax(INF), asum(L1), and nrm2(L2)")
+@nogc pure nothrow auto norm(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType)
 {
     import mir.glas.l1;
     final switch (normType)
@@ -133,7 +134,8 @@ Params:
 Returns:
     Returns normalized input tensor.
 */
-deprecated @nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
+deprecated("Used array based division: tensor[] /= norm, or mir.ndslice.algorithm: tensor.ndEach!(v => v /= norm)")
+@nogc nothrow auto normalized(Range, size_t N)(auto ref Slice!(N, Range) tensor, NormType normType = NormType.L2)
 {
     alias T = DeepElementType!(typeof(tensor));
     auto n = tensor.norm(normType);
@@ -168,7 +170,8 @@ Returns:
     Scaled input tensor.
     
 */
-deprecated @nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
+deprecated("Function will be moved to Mir")
+@nogc nothrow auto scaled(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor, Scalar alpha = 1, Scalar beta = 0)
         if (isNumeric!Scalar)
 {
     tensor.ndEach!((ref v) { v = alpha * (v) + beta; }, Yes.vectorized);
@@ -196,6 +199,7 @@ Params:
     maxValue = Maximal value output tensor should contain.
 
 */
+deprecated("Function will be moved to Mir")
 @nogc auto ranged(Scalar, Range, size_t N)(auto ref Slice!(N, Range) tensor,
         Scalar minValue = 0, Scalar maxValue = 1) if (isNumeric!Scalar)
 {

--- a/source/dcv/core/utils.d
+++ b/source/dcv/core/utils.d
@@ -36,7 +36,8 @@ Returns:
     Return a slice with newly allocated data of type O, with same
     shape as input slice.
 */
-deprecated("Use mir.ndslice.slice.as instead: e.g. mySlice.as!T.slice") static Slice!(N, O*) asType(O, V, size_t N)(Slice!(N, V*) inslice)
+deprecated("Use mir.ndslice.slice.as instead: e.g. mySlice.as!T.slice")
+static Slice!(N, O*) asType(O, V, size_t N)(Slice!(N, V*) inslice)
 {
     static if (__traits(compiles, cast(O)V.init))
     {


### PR DESCRIPTION
Added deprecation messages as suggested in #61. Also deprecated `dcv.core.algorithm.ranged`, as suggested in #44. With norm and asType deprecated, should be good to close #35.

@9il, could you check those messages and tell if you think those should be formatted differently? And if you agree, I would like to close those 3 issues with this PR.
