### PR TITLE
Bilateral filter fix

### DIFF
--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -793,7 +793,7 @@ body
                 foreach (int kc; c - ksh .. c + ksh + 1)
                 {
                     auto ck = (c - kc) ^^ 2;
-					auto cdiff = bc(slice, kr, kc) - p_val;
+                    auto cdiff = bc(slice, kr, kc) - p_val;
                     float c_val = exp((ck + rk) / (-2.0f * sigmaSpace * sigmaSpace));
                     float s_val = exp((cdiff * cdiff) / (-2.0f * sigmaCol * sigmaCol));
                     mask[i, j] = c_val * s_val;

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -751,7 +751,7 @@ Returns:
     Slice of filtered image.
 */
 Slice!(N, OutputType*) bilateralFilter(alias bc = neumann, InputType, OutputType = InputType, size_t N)(Slice!(N,
-        InputType*) slice, float sigma, uint kernelSize, Slice!(N,
+        InputType*) slice, float sigmaCol, float sigmaSpace, uint kernelSize, Slice!(N,
         OutputType*) prealloc = emptySlice!(N, OutputType), TaskPool pool = taskPool) if (N == 2)
 in
 {
@@ -793,8 +793,9 @@ body
                 foreach (int kc; c - ksh .. c + ksh + 1)
                 {
                     auto ck = (c - kc) ^^ 2;
-                    float c_val = exp(-0.5f * ((sqrt(cast(float)(ck + rk)) / sigma) ^^ 2));
-                    float s_val = exp(-0.5f * ((cast(float)(bc(slice, kr, kc) - p_val) / sigma) ^^ 2));
+					auto cdiff = bc(slice, kr, kc) - p_val;
+                    float c_val = exp((ck + rk) / (-2.0f * sigmaSpace * sigmaSpace));
+                    float s_val = exp((cdiff * cdiff) / (-2.0f * sigmaCol * sigmaCol));
                     mask[i, j] = c_val * s_val;
                     ++j;
                 }
@@ -809,7 +810,6 @@ body
             foreach (kr; r - ksh .. r + ksh + 1)
             {
                 j = 0;
-                auto rk = (r - kr) ^^ 2;
                 foreach (kc; c - ksh .. c + ksh + 1)
                 {
                     res_val += (mask[i, j] / mask_sum) * bc(slice, kr, kc);

--- a/source/dcv/multiview/stereo/matching.d
+++ b/source/dcv/multiview/stereo/matching.d
@@ -438,11 +438,11 @@ DisparityRefiner medianDisparityFilter(size_t windowSize = 3)
 /**
 Applies a bilateral filter to the disparity map in order to correct outliers.
 */
-DisparityRefiner bilateralDisparityFilter(uint windowSize, float sigma)
+DisparityRefiner bilateralDisparityFilter(uint windowSize, float sigmaCol, float sigmaSpace)
 {
     void disparityRefiner(const ref StereoPipelineProperties props, DisparityMap disp)
     {
-        disp[] = bilateralFilter(disp, sigma, windowSize * 2, windowSize);
+        disp[] = bilateralFilter(disp, sigmaCol, sigmaSpace, windowSize);
     }
 
     return &disparityRefiner;

--- a/source/dcv/multiview/stereo/matching.d
+++ b/source/dcv/multiview/stereo/matching.d
@@ -442,7 +442,7 @@ DisparityRefiner bilateralDisparityFilter(uint windowSize, float sigma)
 {
     void disparityRefiner(const ref StereoPipelineProperties props, DisparityMap disp)
     {
-        disp[] = bilateralFilter(disp, sigma, windowSize);
+        disp[] = bilateralFilter(disp, sigma, windowSize * 2, windowSize);
     }
 
     return &disparityRefiner;


### PR DESCRIPTION
Bilateral filter should accept two different sigmas: one for intensity weighting and one for spatial weighting.
