### PR TITLE
Renamed histEqual to histEqualize.

### DIFF
--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -29,7 +29,7 @@ $(DL Module contains:
             $(LINK2 #bilateralFilter,bilateralFilter)
             $(LINK2 #medianFilter,medianFilter)
             $(LINK2 #calcHistogram,calcHistogram)
-            $(LINK2 #histEqual,histEqual)
+            $(LINK2 #histEqualize,histEqualize)
             $(LINK2 #erode,erode)
             $(LINK2 #dilate,dilate)
             $(LINK2 #open,open)
@@ -908,7 +908,7 @@ void main()
     Image image = imread("dcv/examples/data/lena.png");
 
     auto slice = image.sliced.rgb2gray;
-    auto equalized = slice.histEqual(slice.byElement.calcHistogram);
+    auto equalized = slice.histEqualize(slice.byElement.calcHistogram);
 
     slice.imshow("Original");
     equalized.imshow("Equalized");
@@ -937,7 +937,7 @@ Params:
 Returns:
     Copy of input image slice with its histogram values equalized.
 */
-Slice!(N, T*) histEqual(T, HistogramType, size_t N)(Slice!(N, T*) slice, HistogramType histogram,
+Slice!(N, T*) histEqualize(T, HistogramType, size_t N)(Slice!(N, T*) slice, HistogramType histogram,
         Slice!(N, T*) prealloc = emptySlice!(N, T))
 in
 {
@@ -985,6 +985,30 @@ body
     return prealloc;
 }
 
+/**
+Histogram Equalization.
+
+Equalize histogram of given image slice. Slice can be 2D for grayscale, and 3D for color images.
+If 3D slice is given, histogram is applied separatelly for each channel.
+
+Deprecated:
+    Renamed to histEqualize. Will be removed in v0.2.0.
+
+Params:
+    Histogram = (template parameter) Histogram type, see $(LINK2 #calcHistogram,calcHistogram) function for details.
+    slice = Input image slice.
+    histogram = Histogram values for input image slice.
+    prealloc = Optional pre-allocated buffer where equalized image is saved.
+
+Returns:
+    Copy of input image slice with its histogram values equalized.
+*/
+deprecated("Use dcv.imgproc.filter.histEqualize")
+Slice!(N, T*) histEqual(T, HistogramType, size_t N)(Slice!(N, T*) slice, HistogramType histogram,
+        Slice!(N, T*) prealloc = emptySlice!(N, T))
+{
+    return histEqualize!(T, HistogramType, N)(slice, histogram, prealloc);
+}
 /**
 Perform morphological $(LINK3 https://en.wikipedia.org/wiki/Erosion_(morphology),erosion).
 

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -985,30 +985,8 @@ body
     return prealloc;
 }
 
-/**
-Histogram Equalization.
+deprecated("Use dcv.imgproc.filter.histEqualize") alias histEqual = histEqualize;
 
-Equalize histogram of given image slice. Slice can be 2D for grayscale, and 3D for color images.
-If 3D slice is given, histogram is applied separatelly for each channel.
-
-Deprecated:
-    Renamed to histEqualize. Will be removed in v0.2.0.
-
-Params:
-    Histogram = (template parameter) Histogram type, see $(LINK2 #calcHistogram,calcHistogram) function for details.
-    slice = Input image slice.
-    histogram = Histogram values for input image slice.
-    prealloc = Optional pre-allocated buffer where equalized image is saved.
-
-Returns:
-    Copy of input image slice with its histogram values equalized.
-*/
-deprecated("Use dcv.imgproc.filter.histEqualize")
-Slice!(N, T*) histEqual(T, HistogramType, size_t N)(Slice!(N, T*) slice, HistogramType histogram,
-        Slice!(N, T*) prealloc = emptySlice!(N, T))
-{
-    return histEqualize!(T, HistogramType, N)(slice, histogram, prealloc);
-}
 /**
 Perform morphological $(LINK3 https://en.wikipedia.org/wiki/Erosion_(morphology),erosion).
 

--- a/tests/performance-tests/source/performance/measure.d
+++ b/tests/performance-tests/source/performance/measure.d
@@ -352,12 +352,12 @@ auto run_dcv_imgproc_filter_medianFilter_5()
     return evalBenchmark(&medianFilter!(neumann, float, float, 2), image, 5, result, taskPool);
 }
 
-auto run_dcv_imgproc_filter_histEqual()
+auto run_dcv_imgproc_filter_histEqualize()
 {
     auto image = slice!ubyte(imsize, imsize);
     auto result = slice!ubyte(imsize, imsize);
     int[256] histogram;
-    return evalBenchmark(&histEqual!(ubyte, int[256], 2), image, histogram, result);
+    return evalBenchmark(&histEqualize!(ubyte, int[256], 2), image, histogram, result);
 }
 
 auto run_dcv_imgproc_filter_erode()

--- a/tests/performance-tests/source/performance/measure.d
+++ b/tests/performance-tests/source/performance/measure.d
@@ -328,14 +328,14 @@ auto run_dcv_imgproc_filter_bilateralFilter_3()
 {
     auto image = slice!float(imsize, imsize);
     auto result = slice!float(imsize, imsize);
-    return evalBenchmark(&bilateralFilter!(neumann, typeof(image), float, 2), image, 0.84, 3, result, taskPool);
+    return evalBenchmark(&bilateralFilter!(neumann, typeof(image), float, 2), image, 0.84, 0.84, 3, result, taskPool);
 }
 
 auto run_dcv_imgproc_filter_bilateralFilter_5()
 {
     auto image = slice!float(imsize, imsize);
     auto result = slice!float(imsize, imsize);
-    return evalBenchmark(&bilateralFilter!(neumann, typeof(image), float, 2), image, 0.84, 5, result, taskPool);
+    return evalBenchmark(&bilateralFilter!(neumann, typeof(image), float, 2), image, 0.84, 0.84, 5, result, taskPool);
 }
 
 auto run_dcv_imgproc_filter_medianFilter_3()


### PR DESCRIPTION
Working on #76

I left histEqual with deprecation message. Will leave the issue until 0.2.0 version comes, and until we remove the histEqual. 

@9il seems ok?