### PR TITLE
dcv:plot fix with high res displays

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -86,7 +86,9 @@
                     "versions": ["ggplotd"]
                 }
             ],
-            "libs": ["gl", "glfw"]
+            "libs": ["glfw"],
+            "lflags-linux": ["-lgl"],
+            "lflags-osx": ["-framework", "OpenGL"]
         }
     ]
 }

--- a/dub.json
+++ b/dub.json
@@ -13,6 +13,9 @@
 
     "targetType": "library",
 
+    "sourcePaths": ["scripts"],
+    "sourceFiles": ["source/dcv/package.d"],
+
     "buildTypes": {
         "unittest-release": {
             "buildOptions": ["unittests", "releaseMode", "optimize", "inline"]

--- a/dub.json
+++ b/dub.json
@@ -87,7 +87,7 @@
                 }
             ],
             "libs": ["glfw"],
-            "lflags-linux": ["-lgl"],
+            "libs-linux": ["gl"],
             "lflags-osx": ["-framework", "OpenGL"]
         }
     ]

--- a/source/dcv/plot/bindings/glfw.d
+++ b/source/dcv/plot/bindings/glfw.d
@@ -279,6 +279,7 @@ extern (C)
     void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
     void glfwSetWindowSize(GLFWwindow* window, int width, int height);
     void glfwWindowHint(int target, int hint);
+    void glfwGetFramebufferSize (GLFWwindow * window, int *width, int *height);
 
     GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun cbfun);
     GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun cbfun);

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -651,16 +651,21 @@ class Figure
     {
         glfwMakeContextCurrent(_glfwWindow);
 
+        int fBufWidth, fBufHeight;
+        glfwGetFramebufferSize(_glfwWindow, &fBufWidth, &fBufHeight);
+
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         glDisable(GL_DEPTH_TEST);
 
-        glViewport(0, 0, width, height);
+        glViewport(0, 0, fBufWidth, fBufHeight);
 
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
 
         glOrtho(0, width, 0, height, 0.1, 1);
-        glPixelZoom(1, -1);
+
+        glPixelZoom(fBufWidth / width, -fBufHeight / height);
+
         glRasterPos3f(0, height - 1, -0.3);
 
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1);


### PR DESCRIPTION
Fixing #89. Also fixing duplicated symbols in dub with 78abbc218ef8f73669afcb6c00db54df52bf0353.

I've been testing b2aa6e271252f2e792eab148d5a3c287ded135cc for some time now on ubuntu 16.04 and macOS sierra for some time now in parallel and seems to be working ok.