### PR TITLE
Added guard for API calls if glfwInit is no good

### DIFF
--- a/source/dcv/plot/bindings/glfw.d
+++ b/source/dcv/plot/bindings/glfw.d
@@ -11,6 +11,8 @@ struct GLFWmonitor
 /*************************************************************************
  * GLFW API tokens
  *************************************************************************/
+immutable GLFW_TRUE = 1;
+immutable GLFW_FALSE = 0;
 
 immutable GLFW_VERSION_MAJOR = 3;
 immutable GLFW_VERSION_MINOR = 1;


### PR DESCRIPTION
closes #105 

Sorry for the commit stained with various edits, but I really hope the diff is simple. Anyhow, what is done:

- Created special exception class if [drawing context hasn't been initialized](https://github.com/libmir/dcv/blob/glfw-guard/source/dcv/plot/figure.d#L117-L134)
- glfwInit result stored in the [`static` variable](https://github.com/libmir/dcv/blob/glfw-guard/source/dcv/plot/figure.d#L877)
- `dcv.plot.figure.Figure` constructors made private, so the only way to construct them is via `dcv.plot.figure.figure` call, to narrow `glfwInit` status checking.
- Added check for the `glfwInit` status in API calls, that throws if its `GLFW_FALSE` as the [glfw docs says](http://www.glfw.org/docs/latest/group__init.html#ga317aac130a235ab08c6db0834907d85e).

Making `Figure` constructors `private` allows us to check for `glfwInit` status only at [main figure construction](https://github.com/libmir/dcv/blob/glfw-guard/source/dcv/plot/figure.d#L151) that all other constructor functions rely on (including `imshow` and `plot`), and in `waitKey`, `imdestroy`. Since Figure objects are [registered by the module](https://github.com/libmir/dcv/blob/glfw-guard/source/dcv/plot/figure.d#L894) for further usage, having those constructors public was actually a bug in the first place.

@9il @timotheecour please let me know what you think. Also @timotheecour it would be great if you could test these changes on the environment where X server is not running.