### PR TITLE
Travis fixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ os:
 
 d:
  - ldc-1.1.0
+ - ldc-1.2.0
  - dmd-2.072.0
+ - dmd-2.074.1
 
 addons:
  apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,6 @@ d:
  - dmd-2.072.0
  - dmd-2.074.1
 
-addons:
- apt:
-  sources:
-   - george-edison55-precise-backports # cmake 3.2.3 
-  packages:
-   - cmake
-   - cmake-data
-
 before_install:
  - "export DISPLAY=:99.0"
  - sh -e /etc/init.d/xvfb start

--- a/scripts/travis_lib_setup.sh
+++ b/scripts/travis_lib_setup.sh
@@ -6,6 +6,6 @@ CACHE_ARCHIVE="dcv.tar.gz"
 cd ${HOME}
 
 wget -O ${CACHE_ARCHIVE} https://drive.google.com/uc?id=0ByTt1Q1eZW5WVk50MS1sWU9wYTg&export=download
-tar -zxf ${CACHE_ARCHIVE} -C ${LD_LIBRARY_PATH}/
+tar -zxf ${CACHE_ARCHIVE} -C ${LD_LIBRARY_PATH//:}/
 
 cd ${CURR_DIR}

--- a/scripts/travis_lib_setup.sh
+++ b/scripts/travis_lib_setup.sh
@@ -6,7 +6,7 @@ CACHE_ARCHIVE="${HOME}/dcv.tar.gz"
 cd ${HOME}
 
 echo Downloading cached archives to ${CACHE_ARCHIVE}
-wget -O ${CACHE_ARCHIVE} https://drive.google.com/uc?id=0ByTt1Q1eZW5WVk50MS1sWU9wYTg&export=download
+wget -O ${CACHE_ARCHIVE} "https://drive.google.com/uc?id=0ByTt1Q1eZW5WVk50MS1sWU9wYTg&export=download"
 
 echo Copying to LD_LIBRARY_PATH...
 tar -zxf ${CACHE_ARCHIVE} -C ${LD_LIBRARY_PATH//:}/

--- a/scripts/travis_lib_setup.sh
+++ b/scripts/travis_lib_setup.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
 CURR_DIR="$(pwd)"
-CACHE_ARCHIVE="dcv.tar.gz"
+CACHE_ARCHIVE="${HOME}/dcv.tar.gz"
 
 cd ${HOME}
 
+echo Downloading cached archives to ${CACHE_ARCHIVE}
 wget -O ${CACHE_ARCHIVE} https://drive.google.com/uc?id=0ByTt1Q1eZW5WVk50MS1sWU9wYTg&export=download
+
+echo Copying to LD_LIBRARY_PATH...
 tar -zxf ${CACHE_ARCHIVE} -C ${LD_LIBRARY_PATH//:}/
+ls ${LD_LIBRARY_PATH//:}
 
 cd ${CURR_DIR}

--- a/scripts/travis_lib_setup.sh
+++ b/scripts/travis_lib_setup.sh
@@ -1,69 +1,11 @@
 #!/bin/bash
 
-function installFFmpeg {
-    if [ "$#" -ne 1 ]; then
-        echo "Invalid argument count"
-    fi
-
-    FFMPEG_VERSION="$1"
-    CURR_DIR="$(pwd)"
-
-    cd ${HOME}
-
-    wget https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_VERSION}.tar.gz
-    tar zxf ${FFMPEG_VERSION}.tar.gz
-
-    cd FFmpeg-${FFMPEG_VERSION}
-    mkdir -p build
-    cd build
-    ../configure --disable-yasm --enable-shared --prefix=${HOME}/install
-
-    make
-    make install
-
-    cd ${CURR_DIR}
-}
-
-function installGlfw {
-    if [ "$#" -ne 1 ]; then
-        echo "Invalid argument count"
-    fi
-
-    GLFW_VERSION="$1"
-    CURR_DIR="$(pwd)"
-
-    cd ${HOME}
-
-    wget https://github.com/glfw/glfw/archive/${GLFW_VERSION}.tar.gz
-    tar zxf ${GLFW_VERSION}.tar.gz
-
-    cd glfw-${GLFW_VERSION}
-    mkdir -p build
-    cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${HOME}/install -DBUILD_SHARED_LIBS=ON ../
-
-    make
-    make install
-
-    cd ${CURR_DIR}
-}
-
-function copyLibs {
-    cp ${HOME}/install/lib/*.so* ${LD_LIBRARY_PATH//:}/
-}
-
-# remember current dir, to return to in the end
 CURR_DIR="$(pwd)"
+CACHE_ARCHIVE="dcv.tar.gz"
 
-# create install directory for libraries
 cd ${HOME}
-mkdir install
 
-# compile libs
-installFFmpeg n2.6.7
-installGlfw 3.2
-
-# copy compiled libraries to ld path.
-copyLibs
+wget -O ${CACHE_ARCHIVE} https://drive.google.com/uc?id=0ByTt1Q1eZW5WVk50MS1sWU9wYTg&export=download
+tar -zxf ${CACHE_ARCHIVE} -C ${LD_LIBRARY_PATH}/
 
 cd ${CURR_DIR}


### PR DESCRIPTION
closes #96 

@9il I've updated the compiler list, and also packed pre-compiled libs in a google drive public archive that gets downloaded and unpacked before the build. Job pre-build preparation came down from ~10min to ~1min.

@wilzbach I've looked at travis' caching options as you've suggested, but failed to understand how would I tell travis not to run my pre-build script after it has cached directories I've listed. I'd be grateful if you could shed some light on this one. 

Tests are failing for reasons not related to this PR.