### PR TITLE
fixes #124

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -48,7 +48,7 @@
             },
             "dependencies":
             {
-                "mir-algorithm": "~>0.6.6"
+                "mir-algorithm": "~>0.9.1"
             }
         },
         {

--- a/source/dcv/core/utils.d
+++ b/source/dcv/core/utils.d
@@ -62,17 +62,17 @@ package(dcv) @nogc pure nothrow
         static struct Range
         {
             import mir.ndslice.iterator;
-            Slice!(SliceKind.contiguous, [1], IotaIterator!size_t) rows;
-            Slice!(SliceKind.contiguous, [1], IotaIterator!size_t) cols;
+            Slice!(SliceKind.contiguous, [1], IotaIterator!ptrdiff_t) rows;
+            Slice!(SliceKind.contiguous, [1], IotaIterator!ptrdiff_t) cols;
         }
 
         size_t kh = max(size_t(1), ks / 2);
 
         Range[4] borders = [
             Range(iota(shape[0]), iota(kh)),
-            Range(iota(shape[0]), iota([kh], shape[1] - kh)),
+            Range(iota(shape[0]), iota!ptrdiff_t([kh], shape[1] - kh)),
             Range(iota(kh), iota(shape[1])),
-            Range(iota([kh], shape[0] - kh), iota(shape[1])),
+            Range(iota!ptrdiff_t([kh], shape[0] - kh), iota(shape[1])),
         ];
 
         return borders;

--- a/source/dcv/core/utils.d
+++ b/source/dcv/core/utils.d
@@ -70,9 +70,9 @@ package(dcv) @nogc pure nothrow
 
         Range[4] borders = [
             Range(iota(shape[0]), iota(kh)),
-            Range(iota(shape[0]), iota!ptrdiff_t([kh], shape[1] - kh)),
+            Range(iota(shape[0]), iota([kh], shape[1] - kh)),
             Range(iota(kh), iota(shape[1])),
-            Range(iota!ptrdiff_t([kh], shape[0] - kh), iota(shape[1])),
+            Range(iota([kh], shape[0] - kh), iota(shape[1])),
         ];
 
         return borders;


### PR DESCRIPTION
fixes https://github.com/libmir/dcv/issues/124
fixes https://github.com/libmir/dcv/issues/126

## OLD
@9il please double check this is doing the right thing
Also, should the right thing to do be to make `I = sizediff_t` in the other iota functions in mir.ndslice.topology?
```
Slice!(Contiguous, [N], IotaIterator!I)
iota
    (I, size_t N)(size_t[N] lengths, I start)
    if (isIntegral!I || isPointer!I)

Slice!(Contiguous, [N], StrideIterator!(IotaIterator!I))
iota
    (I, size_t N)(size_t[N] lengths, I start, size_t stride)
    if (isIntegral!I || isPointer!I)
```

so that
`iota!ptrdiff_t([kh], shape[0] - kh)` would just be equivalent to `iota([kh], shape[0] - kh)`  ?


