### PR TITLE
dcv:io -> dcv:imageio

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,7 @@
     "license": "BSL-1.0",
     "dependencies": {
         "dcv:core": "*",
-        "dcv:io": "*",
+        "dcv:imageio": "*",
         "dcv:videoio": "*",
         "dcv:plot": "*"
     },
@@ -46,10 +46,10 @@
             }
         },
         {
-            "name": "io",
+            "name": "imageio",
             "description": "Image I/O package.",
             "sourcePaths": [
-                "source/dcv/io"
+                "source/dcv/imageio"
             ],
             "dependencies":{
                 "dcv:core": "*",
@@ -67,7 +67,7 @@
             "sourcePaths": [ "source/dcv/videoio/"],
             "dependencies": {
                 "dcv:core": "*",
-                "dcv:io": "*",
+                "dcv:imageio": "*",
                 "ffmpeg-d": "~>4.4.1"
             }
         },

--- a/examples/convexhull/dub.json
+++ b/examples/convexhull/dub.json
@@ -6,6 +6,6 @@
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
         "dcv:plot": {"path": "../../"},
-        "dcv:io": {"path": "../../"}
+        "dcv:imageio": {"path": "../../"}
 	}
 }

--- a/examples/convexhull/source/app.d
+++ b/examples/convexhull/source/app.d
@@ -1,7 +1,7 @@
 import std.stdio;
 
 import dcv.core;
-import dcv.io.image;
+import dcv.imageio.image;
 import dcv.plot;
 import dcv.imgproc;
 import dcv.measure;

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -9,7 +9,7 @@ This example demonstrates corner detection algorithms - Harris, and Shi-Tomasi.
 * dcv.features
 * dcv.imgproc.color
 * dcv.imgproc.filter
-* dcv.io
+* dcv.imageio
 
 ## Example description
 

--- a/examples/features/dub.json
+++ b/examples/features/dub.json
@@ -5,7 +5,7 @@
     "authors": ["relja"],
     "dependencies": {
         "dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
     }
 }

--- a/examples/features/source/app.d
+++ b/examples/features/source/app.d
@@ -10,7 +10,7 @@ import dcv.core;
 import dcv.features;
 import dcv.imgproc.color;
 import dcv.imgproc.filter;
-import dcv.io;
+import dcv.imageio;
 import dcv.plot;
 
 

--- a/examples/filter/README.md
+++ b/examples/filter/README.md
@@ -8,7 +8,7 @@ Should also provide insight to basic setup for any image processing, such as ima
 ## Modules used
 * dcv.core.image
 * dcv.core.utils
-* dcv.io
+* dcv.imageio
 * dcv.imgproc
 
 ## Source Image

--- a/examples/filter/dub.json
+++ b/examples/filter/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["Relja Ljubobratovic"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/filter/source/app.d
+++ b/examples/filter/source/app.d
@@ -12,7 +12,7 @@ import std.array : array;
 import mir.ndslice;
 
 import dcv.core : Image, ranged, ImageFormat;
-import dcv.io : imread, imwrite;
+import dcv.imageio : imread, imwrite;
 import dcv.imgproc;
 import dcv.plot;
 

--- a/examples/imgmanip/README.md
+++ b/examples/imgmanip/README.md
@@ -7,7 +7,7 @@ This example should demonstrate how to apply various image (spatial) transformat
 ## Modules used
 * dcv.core;
 * dcv.imgproc.imgmanip;
-* dcv.io;
+* dcv.imageio;
 
 ## Resize
 

--- a/examples/imgmanip/dub.json
+++ b/examples/imgmanip/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["relja"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/imgmanip/source/app.d
+++ b/examples/imgmanip/source/app.d
@@ -9,7 +9,7 @@ import mir.ndslice;
 
 import dcv.core;
 import dcv.imgproc.imgmanip;
-import dcv.io;
+import dcv.imageio;
 
 void main()
 {

--- a/examples/maze/dub.json
+++ b/examples/maze/dub.json
@@ -5,7 +5,7 @@
     "authors": ["Ferhat Kurtulmuş"],
     "dependencies": {
         "dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
     }
 }

--- a/examples/maze/source/app.d
+++ b/examples/maze/source/app.d
@@ -1,9 +1,9 @@
 
 import std.stdio, std.math;
-import dcv.io.image : imread, imwrite;
+import dcv.imageio.image : imread, imwrite;
 
 import dcv.core;
-import dcv.io.image;
+import dcv.imageio.image;
 import dcv.plot;
 import dcv.imgproc;
 import dcv.measure;

--- a/examples/measure/README.md
+++ b/examples/measure/README.md
@@ -13,7 +13,7 @@
 ## code
 ```d
 import dcv.core;
-import dcv.io.image;
+import dcv.imageio.image;
 import dcv.plot;
 import dcv.imgproc;
 import dcv.measure;

--- a/examples/measure/dub.json
+++ b/examples/measure/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["Ferhat Kurtulmuş"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/measure/source/app.d
+++ b/examples/measure/source/app.d
@@ -1,9 +1,9 @@
 
 import std.stdio;
-import dcv.io.image : imread, imwrite;
+import dcv.imageio.image : imread, imwrite;
 
 import dcv.core;
-import dcv.io.image;
+import dcv.imageio.image;
 import dcv.plot;
 import dcv.imgproc;
 import dcv.measure;

--- a/examples/morph/README.md
+++ b/examples/morph/README.md
@@ -5,7 +5,7 @@ This example should demonstrate how to perform morphological operation on binary
 ## Modules used
 
 *   dcv.core
-*   dcv.io
+*   dcv.imageio
 *   dcv.imgproc
 *   dcv.plot
 

--- a/examples/morph/dub.json
+++ b/examples/morph/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["Relja Ljubobratovic"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/morph/source/app.d
+++ b/examples/morph/source/app.d
@@ -5,7 +5,7 @@ module dcv.example.morph;
  */
 
 import dcv.core;
-import dcv.io;
+import dcv.imageio;
 import dcv.imgproc;
 import dcv.plot;
 

--- a/examples/plot/README.md
+++ b/examples/plot/README.md
@@ -6,7 +6,7 @@ This example should demonstrate how image plotting mechanism works in DCV, and h
 
 ## Modules used
 * dcv.core
-* dcv.io
+* dcv.imageio
 * dcv.imgproc
 * dcv.plot.figure
 

--- a/examples/plot/dub.json
+++ b/examples/plot/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["Relja Ljubobratovic"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/plot/source/app.d
+++ b/examples/plot/source/app.d
@@ -8,7 +8,7 @@ import core.stdc.stdio;
 import std.stdio;
 
 import dcv.core;
-import dcv.io;
+import dcv.imageio;
 import dcv.imgproc;
 import dcv.plot.figure;
 

--- a/examples/rht/README.md
+++ b/examples/rht/README.md
@@ -10,7 +10,7 @@ Should showcases a few basics such as image i/o, conversion to Slice object etc.
 ## Modules used
 * dcv.core.image
 * dcv.core.utils
-* dcv.io
+* dcv.imageio
 * dcv.imgproc
 * dcv.features.rht
 

--- a/examples/rht/dub.json
+++ b/examples/rht/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["Dmitry Olshansky"],
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/rht/source/app.d
+++ b/examples/rht/source/app.d
@@ -13,7 +13,7 @@ import mir.ndslice;
 
 import dcv.core.image : Image, ImageFormat;
 import dcv.core.utils : clip;
-import dcv.io : imread, imwrite;
+import dcv.imageio : imread, imwrite;
 import dcv.imgproc;
 import dcv.features.rht;
 

--- a/examples/tracking/hornschunck/README.md
+++ b/examples/tracking/hornschunck/README.md
@@ -6,7 +6,7 @@ This example demonstrates usage of Pyramidal Horn-Schunck optical flow algorithm
 
 ## Modules used
 * dcv.core
-* dcv.io
+* dcv.imageio
 * dcv.imgproc.imgmanip
 * dcv.tracking.opticalflow
 * dcv.plot.opticalflow

--- a/examples/tracking/hornschunck/dub.json
+++ b/examples/tracking/hornschunck/dub.json
@@ -5,7 +5,7 @@
 	"authors": ["relja"],
 	"dependencies": {
         "dcv:core": {"path": "../../../"},
-        "dcv:io": {"path": "../../../"},
+        "dcv:imageio": {"path": "../../../"},
         "dcv:plot": {"path": "../../../"}
 	}
 }

--- a/examples/tracking/hornschunck/source/app.d
+++ b/examples/tracking/hornschunck/source/app.d
@@ -10,7 +10,7 @@ import std.conv : to;
 import mir.ndslice;
 
 import dcv.core;
-import dcv.io;
+import dcv.imageio;
 
 import dcv.imgproc.imgmanip : warp;
 import dcv.tracking.opticalflow : HornSchunckFlow, HornSchunckProperties, DensePyramidFlow;

--- a/examples/tracking/klt/README.md
+++ b/examples/tracking/klt/README.md
@@ -4,7 +4,7 @@ This example demonstrates usage of Pyramidal Lucas-Kanade Optical Flow algorithm
 
 ## Modules used
  * dcv.core;
- * dcv.io;
+ * dcv.imageio;
  * dcv.imgproc.filter : filterNonMaximum;
  * dcv.imgproc.color : gray2rgb;
  * dcv.features.corner.harris : shiTomasiCorners;

--- a/examples/tracking/klt/dub.json
+++ b/examples/tracking/klt/dub.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "dcv:core": {"path": "../../../"},
         "dcv:videoio": {"path": "../../../"},
-        "dcv:io": {"path": "../../../"},
+        "dcv:imageio": {"path": "../../../"},
         "dcv:plot": {"path": "../../../"}
     }
 }

--- a/examples/tracking/klt/source/app.d
+++ b/examples/tracking/klt/source/app.d
@@ -12,7 +12,7 @@ import std.array : array;
 import mir.ndslice;
 
 import dcv.core;
-import dcv.io;
+import dcv.imageio;
 import dcv.videoio;
 import dcv.imgproc.filter : filterNonMaximum;
 import dcv.imgproc.color : gray2rgb;

--- a/examples/unrevised_stereo/stereo/README.md
+++ b/examples/unrevised_stereo/stereo/README.md
@@ -5,7 +5,7 @@ This example shows how to use stereo matching utilities in DCV.
 
 ## Modules used
 * dcv.imgproc
-* dcv.io.image
+* dcv.imageio.image
 * dcv.plot
 * dcv.multiview.stereo.matching
 

--- a/examples/unrevised_stereo/stereo/dub.json
+++ b/examples/unrevised_stereo/stereo/dub.json
@@ -7,7 +7,7 @@
 	"copyright": "Copyright © 2016, Henry Gouk",
 	"dependencies": {
 		"dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
         "dcv:plot": {"path": "../../"}
 	}
 }

--- a/examples/unrevised_stereo/stereo/source/app.d
+++ b/examples/unrevised_stereo/stereo/source/app.d
@@ -7,7 +7,7 @@ import std.stdio;
 import mir.ndslice.algorithm : reduce;
 
 import dcv.imgproc;
-import dcv.io.image;
+import dcv.imageio.image;
 import dcv.plot;
 import dcv.multiview.stereo.matching;
 

--- a/examples/video/README.md
+++ b/examples/video/README.md
@@ -7,7 +7,7 @@ This example should demonstrate how to read video streams using dcv library.
 ## Modules used
 * dcv.core;
 * dcv.imgproc.color;
-* dcv.io;
+* dcv.imageio;
 * dcv.plot.figure;
 
 ## Disclaimer
@@ -17,7 +17,7 @@ these utilities should look like.
 
 ### InputStream usage
 
-Input video streaming utility is located in the dcv.io.video.input module, defined as 
+Input video streaming utility is located in the dcv.imageio.video.input module, defined as 
 InputStream class. In the demo application, we open the input video stream, read the 
 video frame by frame, and show its content on the screen.
 
@@ -91,7 +91,7 @@ code, please take a look in the dcv/examples/video/source/app.d file.
 
 ### More examples
 
-For more extensive example, please take a look into a unit test in the dcv.io.video module (source/dcv/io/video.package.d file). This is actually a functional test proving the video streaming utilities work as expected. Please keep in mind that these modules are not done yet, and will surely change in future.
+For more extensive example, please take a look into a unit test in the dcv.imageio.video module (source/dcv/io/video.package.d file). This is actually a functional test proving the video streaming utilities work as expected. Please keep in mind that these modules are not done yet, and will surely change in future.
 
 
 

--- a/source/dcv/imageio/image.d
+++ b/source/dcv/imageio/image.d
@@ -4,7 +4,7 @@ Copyright: Copyright Relja Ljubobratovic 2016.
 Authors: Relja Ljubobratovic
 License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - Version 1.0).
 */
-module dcv.io.image;
+module dcv.imageio.image;
 /*
 TODO: write wrappers and  use libjpeg, libpng, libtiff, openexr.
 v0.1 norm:

--- a/source/dcv/imageio/package.d
+++ b/source/dcv/imageio/package.d
@@ -8,9 +8,9 @@ Authors: Relja Ljubobratovic
 License: $(LINK3 http://www.boost.org/LICENSE_1_0.txt, Boost Software License - Version 1.0).
 */
 
-module dcv.io;
+module dcv.imageio;
 
-public import dcv.io.image;
+public import dcv.imageio.image;
 
 /*
 TODO: split sub-modules. (image, video, filestorage etc.)

--- a/source/dcv/imgproc/convolution.d
+++ b/source/dcv/imgproc/convolution.d
@@ -4,7 +4,7 @@ Module introduces $(LINK3 https://en.wikipedia.org/wiki/Kernel_(image_processing
 Following example loads famous image of Lena Söderberg and performs gaussian blurring by convolving the image with gaussian kernel.
 
 ----
-import dcv.io.image : imread, ReadParams;
+import dcv.imageio.image : imread, ReadParams;
 import dcv.core.image : Image, asType;
 import dcv.imgproc.convolution : conv;
 

--- a/source/dcv/imgproc/filter.d
+++ b/source/dcv/imgproc/filter.d
@@ -934,7 +934,7 @@ If 3D slice is given, histogram is applied separatelly for each channel.
 
 Example:
 ----
-import dcv.core, dcv.io, dcv.imgproc, dcv.plot;
+import dcv.core, dcv.imageio, dcv.imgproc, dcv.plot;
 
 void main()
 {

--- a/source/dcv/package.d
+++ b/source/dcv/package.d
@@ -5,7 +5,7 @@ public {
     import dcv.features;
     import dcv.measure;
     import dcv.imgproc;
-    import dcv.io;
+    import dcv.imageio;
     import dcv.videoio;
     import dcv.plot;
     import dcv.tracking;

--- a/source/dcv/videoio/common.d
+++ b/source/dcv/videoio/common.d
@@ -21,7 +21,7 @@ import ffmpeg.libswscale;
 import ffmpeg.libavdevice;
 import ffmpeg.libavfilter;
 
-public import dcv.io.image;
+public import dcv.imageio.image;
 
 /**
 Exception related to streaming operations.

--- a/source/dcv/videoio/input.d
+++ b/source/dcv/videoio/input.d
@@ -43,7 +43,7 @@ import ffmpeg.libavdevice;
 import ffmpeg.libavfilter;
 
 public import dcv.videoio.common;
-public import dcv.io.image;
+public import dcv.imageio.image;
 
 /**
 Input streaming type - file or webcam (live)

--- a/source/dcv/videoio/output.d
+++ b/source/dcv/videoio/output.d
@@ -55,7 +55,7 @@ import ffmpeg.libavdevice;
 import ffmpeg.libavfilter;
 
 public import dcv.videoio.common;
-public import dcv.io.image;
+public import dcv.imageio.image;
 
 /**
 Output stream definition properties.

--- a/tests/performance-tests/dub.json
+++ b/tests/performance-tests/dub.json
@@ -7,6 +7,6 @@
     "dependencies": 
     {
         "dcv:core": {"path": "../../"},
-        "dcv:io": {"path": "../../"}
+        "dcv:imageio": {"path": "../../"}
     }
 }

--- a/tests/performance-tests/source/performance/measure.d
+++ b/tests/performance-tests/source/performance/measure.d
@@ -19,7 +19,7 @@ import dcv.imgproc;
 import dcv.features;
 import dcv.multiview;
 import dcv.tracking;
-import dcv.io;
+import dcv.imageio;
 
 import mir.ndslice;
 


### PR DESCRIPTION
Rather large diff, but 99% automated search and replace of `io -> imageio`.

Merging right away.