### PR TITLE
Implementation of the skeletonize function for binary regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Library is licensed under Boost Software License - Version 1.0. Some modules in 
 ## dcv revision/revival notes
 
 * This is an effort to make dcv work with the recent versions of LDC, mir libraries and stuff
-* I consider this as a temporary git repo which will be deleted after a big PR to the original DCV repo (if the maintainers accept).
 
 ## Done so far:
 
@@ -68,7 +67,7 @@ Library is licensed under Boost Software License - Version 1.0. Some modules in 
 ## newly-implemented functionality:
 * Otsu's method for threshold calculation
 * dcv.measure module with refcounted image types: labelling connected regions, moments, ellipsefit, convexhull, findContours, area, perimeter
-* dcv.morphology module with distanceTransform (more planned like watershed, skeletonize, end-points, junctions)
+* dcv.morphology module with distanceTransform (more planned like watershed, ~~skeletonize~~, end-points, junctions)
 * Switched to modern OpenGL for rendering, by reserving the legacy gl support. use "subConfigurations": {"dcv:core": "legacygl"} for the legacy GL support.
 * New plot primitives like drawLine and drawCircle at Opengl rendering level. the function plot2imslice copies the rendered buffer to a slice. Take a look at the convexhull examples for more.
 

--- a/examples/skeletonize/.gitignore
+++ b/examples/skeletonize/.gitignore
@@ -1,0 +1,8 @@
+.dub
+docs.json
+__dummy.html
+*.o
+*.obj
+*.exe
+/filter
+*.selections.json

--- a/examples/skeletonize/dub.json
+++ b/examples/skeletonize/dub.json
@@ -1,0 +1,11 @@
+{
+	"name": "skeletonize",
+	"description": "skeletonization of binary regions.",
+	"copyright": "Copyright © 2022, Ferhat Kurtulmuş",
+	"authors": ["Ferhat Kurtulmuş"],
+	"dependencies": {
+		"dcv:core": {"path": "../../"},
+        "dcv:imageio": {"path": "../../"},
+        "dcv:plot": {"path": "../../"}
+	}
+}

--- a/examples/skeletonize/source/app.d
+++ b/examples/skeletonize/source/app.d
@@ -1,0 +1,24 @@
+import std.stdio;
+
+import dcv.imageio.image : imread, imwrite;
+import dcv.core;
+import dcv.plot;
+import dcv.imgproc;
+import dcv.morphology;
+
+import mir.rc;
+
+void main()
+{
+    Image img = imread("../data/test_labels.png");
+
+    Slice!(ubyte*, 2, Contiguous) gray = img.sliced.rgb2gray; // the test image is already binary here
+
+    auto skel = skeletonize2D(gray);
+
+    imwrite(skel.asImage(ImageFormat.IF_MONO), "result/skel.png");
+
+    imshow(skel, "skel");
+    
+    waitKey();
+}

--- a/source/dcv/morphology/package.d
+++ b/source/dcv/morphology/package.d
@@ -4,4 +4,5 @@ public {
     import dcv.morphology.distancetransform;
     import dcv.morphology.floodfill;
     import dcv.morphology.geometry;
+    import dcv.morphology.skeletonize;
 }

--- a/source/dcv/morphology/skeletonize.d
+++ b/source/dcv/morphology/skeletonize.d
@@ -15,7 +15,7 @@ import mir.rc;
 
 Params:
     binary = Input binary image of ubyte. Agnostic to SliceKind
-Returns a refcounted Slice representing one pixel length skeletons of the binary regions. The resulting slice is Canonical.
+Returns a refcounted Slice representing one pixel width skeletons of the binary regions. The resulting slice is Canonical.
 */
 Slice!(RCI!ubyte, 2LU, Canonical) skeletonize2D(InputType)(auto ref InputType binary, int whiteValue = 255){
 

--- a/source/dcv/morphology/skeletonize.d
+++ b/source/dcv/morphology/skeletonize.d
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2021- Ferhat Kurtulmuş
+Boost Software License - Version 1.0 - August 17th, 2003
+*/
+module dcv.morphology.skeletonize;
+
+import mir.ndslice;
+import mir.rc;
+
+@nogc nothrow:
+
+// A rewrite of https://github.com/scikit-image/scikit-image/blob/main/skimage/morphology/_skeletonize_cy.pyx
+
+/** Apply fast skeletonize algorithm to given binary image.
+
+Params:
+    binary = Input binary image of ubyte. Agnostic to SliceKind
+Returns a refcounted Slice representing one pixel length skeletons of the binary regions. The resulting slice is Canonical.
+*/
+Slice!(RCI!ubyte, 2LU, Canonical) skeletonize2D(InputType)(auto ref InputType binary, int whiteValue = 255){
+
+    // we copy over the image into a larger version with a single pixel border
+    // this removes the need to handle border cases below
+
+    immutable size_t nrows = binary.shape[0] + 2;
+    immutable size_t ncols = binary.shape[1] + 2;
+
+    auto skeleton = uninitRCslice!ubyte(nrows, ncols);
+    skeleton[] = 0;
+    
+    skeleton[1..$-1, 1..$-1] = binary[]; // copy original data in the bordered frame
+    
+    auto cleaned_skeleton = rcslice!ubyte(skeleton.shape[0], skeleton.shape[1]);
+    cleaned_skeleton[] = skeleton[]; // dup
+
+    bool pixel_removed = true;
+
+    while(pixel_removed){
+        pixel_removed = false;
+
+        // there are two phases, in the first phase, pixels labeled
+        // (see below) 1 and 3 are removed, in the second 2 and 3
+
+        // nogil can't iterate through `(True, False)` because it is a Python
+        // tuple. Use the fact that 0 is Falsy, and 1 is truthy in C
+        // for the iteration instead.
+        // for first_pass in (True, False):
+        bool first_pass;
+        foreach(pass_num; 0..2){
+            first_pass = (pass_num == 0);
+            foreach(row; 1..nrows-1){
+                foreach(col; 1..ncols-1){
+                    // all set pixels ...
+
+                    if(skeleton[row, col]){
+                        // are correlated with a kernel
+                        // (coefficients spread around here ...)
+                        // to apply a unique number to every
+                        // possible neighborhood ...
+
+                        // which is used with the lut to find the
+                        // "connectivity type"
+
+                        immutable neighbors = lut[skeleton[row - 1, col - 1] / whiteValue +
+                                                2 * skeleton[row - 1, col] / whiteValue +
+                                                4 * skeleton[row - 1, col + 1] / whiteValue +
+                                                8 * skeleton[row, col + 1] / whiteValue +
+                                                16 * skeleton[row + 1, col + 1] / whiteValue +
+                                                32 * skeleton[row + 1, col] / whiteValue +
+                                                64 * skeleton[row + 1, col - 1] / whiteValue +
+                                                128 * skeleton[row, col - 1] / whiteValue];
+
+                        if (neighbors == 0)
+                            continue;
+                        else if ((neighbors == 3) ||
+                                (neighbors == 1 && first_pass) ||
+                                (neighbors == 2 && !first_pass)){
+                            // Remove the pixel
+                            cleaned_skeleton[row, col] = 0;
+                            pixel_removed = true;
+                        }
+                    }
+                }
+            }
+            // once a step has been processed, the original skeleton
+            // is overwritten with the cleaned version
+            skeleton[] = cleaned_skeleton[];
+        }
+    }
+
+    // because of the dropborders the resulting slice is Canonical
+    // with an extra copying process it can be converted to a Contiguous Slice if this is needed.
+    return skeleton.dropBorders; 
+}
+
+private immutable ubyte[256] lut = [0, 0, 0, 1, 0, 0, 1, 3, 0, 0, 3, 1, 1, 0,
+                                    1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0,
+                                    3, 0, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    2, 0, 0, 0, 3, 0, 2, 2, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+                                    0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0,
+                                    3, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 3, 0,
+                                    2, 0, 0, 0, 3, 1, 0, 0, 1, 3, 0, 0, 0, 0,
+                                    0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 1, 3, 1, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 1, 3,
+                                    0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                    2, 3, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                                    0, 0, 3, 3, 0, 1, 0, 0, 0, 0, 2, 2, 0, 0,
+                                    2, 0, 0, 0];


### PR DESCRIPTION
This is a rewrite of scikit-image's 2D fast skeletonized algorithm[1] written in cython. An example usage is also included in the examples folder.

1: https://github.com/scikit-image/scikit-image/blob/main/skimage/morphology/_skeletonize_cy.pyx