### PR TITLE
replace imageformats with gamut. remove alpha

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -54,7 +54,7 @@
             ],
             "dependencies":{
                 "dcv:core": "*",
-                "imageformats": "7.0.2"
+                "gamut": "~>1.0.0"
             },
             "buildTypes": {
                 "unittest-release": {

--- a/source/dcv/core/image.d
+++ b/source/dcv/core/image.d
@@ -27,22 +27,24 @@ enum ImageFormat
 {
     IF_UNASSIGNED = 0, /// Not assigned format.
     IF_MONO, /// Mono, single channel format.
-    IF_MONO_ALPHA, /// Mono with alpha channel.
+    //IF_MONO_ALPHA, /// Mono with alpha channel.
     IF_RGB, /// RGB format.
     IF_BGR, /// BGR format.
     IF_YUV, /// YUV (YCbCr) format.
-    IF_RGB_ALPHA, /// RGB format with alpha.
-    IF_BGR_ALPHA /// BGR format with alpha.
+    //IF_RGB_ALPHA, /// RGB format with alpha.
+    //IF_BGR_ALPHA /// BGR format with alpha.
 }
 
-immutable size_t[] imageFormatChannelCount = [0, // unassigned
+
+immutable size_t[] imageFormatChannelCount = [
+    0, // unassigned
     1, // mono
-    2, // mono alpha
+    //2, // mono alpha
     3, // rgb
     3, // bgr
     3, // yuv
-    4, // rgba
-    4 // bgra
+    //4, // rgba
+    //4 // bgra
     ];
 
 /// Bit depth of a pixel in an image.
@@ -379,24 +381,38 @@ public:
 
         if (_depth == BitDepth.BD_8)
         {
+            foreach(i, v; data!ubyte){
+                newim.data!T[i] = cast(T)v;
+            }
+            /*
             foreach (v1, ref v2; lockstep(data!ubyte, newim.data!T))
             {
                 v2 = cast(T)v1;
-            }
+            }*/
+
         }
         else if (_depth == BitDepth.BD_16)
         {
+            foreach(i, v; data!ushort){
+                newim.data!T[i] = cast(T)v;
+            }
+            /*
             foreach (v1, ref v2; lockstep(data!ushort, newim.data!T))
             {
                 v2 = cast(T)v1;
-            }
+            }*/
         }
         else if (_depth == BitDepth.BD_32)
         {
+            foreach(i, v; data!float){
+                newim.data!T[i] = cast(T)v;
+            }
+            /*
             foreach (v1, ref v2; lockstep(data!float, newim.data!T))
             {
                 v2 = cast(T)v1;
             }
+            */
         }
 
         return newim;
@@ -606,15 +622,15 @@ Image asImage(Iterator, size_t N, SliceKind kind)(Slice!(Iterator, N, kind) slic
         case 1:
             format = ImageFormat.IF_MONO;
             break;
-        case 2:
+        /+case 2:
             format = ImageFormat.IF_MONO_ALPHA;
-            break;
+            break;+/
         case 3:
             format = ImageFormat.IF_RGB;
             break;
-        case 4:
+        /+case 4:
             format = ImageFormat.IF_RGB_ALPHA;
-            break;
+            break;+/
         default:
             import std.conv : to;
 

--- a/source/dcv/plot/drawprimitives.d
+++ b/source/dcv/plot/drawprimitives.d
@@ -75,17 +75,18 @@ GLuint loadTexture(ubyte* imptr, uint w, uint h){
     glGenTextures(1, &textureId); 
     glBindTexture(GL_TEXTURE_2D, textureId);
     
+    /+
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);    
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    /+
+    +/
     glTexParameterf(GL_TEXTURE_2D,GL_TEXTURE_MIN_FILTER,GL_NEAREST);
     glTexParameterf(GL_TEXTURE_2D,GL_TEXTURE_MAG_FILTER,GL_NEAREST);
     glTexParameterf(GL_TEXTURE_2D,GL_TEXTURE_WRAP_S,GL_CLAMP_TO_EDGE);
     glTexParameterf(GL_TEXTURE_2D,GL_TEXTURE_WRAP_T,GL_CLAMP_TO_EDGE);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    +/
+    
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, w, h, 0, GL_RGB, GL_UNSIGNED_BYTE, imptr);
     glGenerateMipmap(GL_TEXTURE_2D);
 

--- a/source/dcv/plot/figure.d
+++ b/source/dcv/plot/figure.d
@@ -458,7 +458,7 @@ class Figure
 
         int _width = 0;
         int _height = 0;
-        ubyte[] _data = void;
+        ubyte[] _data = null;
         string _title = "";
 
         MouseCallback _mouseCallback = null;
@@ -1065,9 +1065,9 @@ Image adoptImage(Image image)
     import mir.ndslice.topology;
     switch (showImage.format)
     {
-    case ImageFormat.IF_RGB_ALPHA:
+    /+case ImageFormat.IF_RGB_ALPHA:
         showImage = showImage.sliced[0 .. $, 0 .. $, 0 .. 2].asImage(ImageFormat.IF_RGB);
-        break;
+        break;+/
     case ImageFormat.IF_BGR:
         foreach (e; showImage.sliced.pack!1.flattened)
         {
@@ -1076,7 +1076,7 @@ Image adoptImage(Image image)
             e[2] = t;
         }
         break;
-    case ImageFormat.IF_BGR_ALPHA:
+    /+case ImageFormat.IF_BGR_ALPHA:
         foreach (e; showImage.sliced.pack!1.flattened)
         {
             auto t = e[0];
@@ -1084,7 +1084,7 @@ Image adoptImage(Image image)
             e[2] = t;
         }
         showImage = showImage.sliced[0 .. $, 0 .. $, 0 .. 2].asImage(ImageFormat.IF_RGB);
-        break;
+        break;+/
     case ImageFormat.IF_YUV:
         showImage = showImage.sliced.yuv2rgb!ubyte.asImage(ImageFormat.IF_RGB);
         break;

--- a/source/dcv/videoio/common.d
+++ b/source/dcv/videoio/common.d
@@ -106,7 +106,7 @@ class AVStarter
 
 immutable IF_MONO_TYPES = [AVPixelFormat.AV_PIX_FMT_GRAY8];
 
-immutable IF_MONO_ALPHA_TYPES = [AVPixelFormat.AV_PIX_FMT_GRAY8A];
+// immutable IF_MONO_ALPHA_TYPES = [AVPixelFormat.AV_PIX_FMT_GRAY8A];
 
 immutable IF_YUV_TYPES = [
     AVPixelFormat.AV_PIX_FMT_YUV410P, AVPixelFormat.AV_PIX_FMT_YUV411P,
@@ -118,22 +118,22 @@ immutable IF_RGB_TYPES = [
     AVPixelFormat.AV_PIX_FMT_RGB0, AVPixelFormat.AV_PIX_FMT_RGB24, AVPixelFormat.AV_PIX_FMT_RGB4,
     AVPixelFormat.AV_PIX_FMT_RGB8
 ];
-
+/+
 immutable IF_RGB_ALPHA_TYPES = [AVPixelFormat.AV_PIX_FMT_ARGB, AVPixelFormat.AV_PIX_FMT_RGBA];
-
++/
 immutable IF_BGR_TYPES = [
     AVPixelFormat.AV_PIX_FMT_BGR0, AVPixelFormat.AV_PIX_FMT_BGR24, AVPixelFormat.AV_PIX_FMT_BGR4,
     AVPixelFormat.AV_PIX_FMT_BGR8
 ];
 
-immutable IF_BGR_ALPHA_TYPES = [AVPixelFormat.AV_PIX_FMT_ABGR, AVPixelFormat.AV_PIX_FMT_BGRA];
+// immutable IF_BGR_ALPHA_TYPES = [AVPixelFormat.AV_PIX_FMT_ABGR, AVPixelFormat.AV_PIX_FMT_BGRA];
 
 alias IF_MONO_PREFERED = AVPixelFormat.AV_PIX_FMT_GRAY8;
-alias IF_MONO_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_GRAY8A;
+// alias IF_MONO_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_GRAY8A;
 alias IF_RGB_PREFERED = AVPixelFormat.AV_PIX_FMT_RGB24;
-alias IF_RGB_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_RGBA;
+// alias IF_RGB_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_RGBA;
 alias IF_BGR_PREFERED = AVPixelFormat.AV_PIX_FMT_BGR24;
-alias IF_BGR_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_BGRA;
+// alias IF_BGR_ALPHA_PREFERED = AVPixelFormat.AV_PIX_FMT_BGRA;
 alias IF_YUV_PREFERED = AVPixelFormat.AV_PIX_FMT_YUV444P;
 
 AVPixelFormat convertDepricatedPixelFormat(AVPixelFormat pix)
@@ -176,22 +176,27 @@ ImageFormat AVPixelFormat_to_ImageFormat(AVPixelFormat format)
     {
         return ImageFormat.IF_BGR;
     }
+    /+
     else if (IF_RGB_ALPHA_TYPES.find(format))
     {
         return ImageFormat.IF_RGB_ALPHA;
     }
+    
     else if (IF_BGR_ALPHA_TYPES.find(format))
     {
         return ImageFormat.IF_BGR_ALPHA;
     }
+    +/
     else if (IF_MONO_TYPES.find(format))
     {
         return ImageFormat.IF_MONO;
     }
+    /+
     else if (IF_MONO_ALPHA_TYPES.find(format))
     {
         return ImageFormat.IF_MONO_ALPHA;
     }
+    +/
     else
     {
         enforce(0, "Format type is not supported");
@@ -205,16 +210,16 @@ AVPixelFormat ImageFormat_to_AVPixelFormat(ImageFormat format)
     {
     case ImageFormat.IF_MONO:
         return IF_MONO_PREFERED;
-    case ImageFormat.IF_MONO_ALPHA:
-        return IF_MONO_ALPHA_PREFERED;
+    /+case ImageFormat.IF_MONO_ALPHA:
+        return IF_MONO_ALPHA_PREFERED;+/
     case ImageFormat.IF_BGR:
         return IF_BGR_PREFERED;
-    case ImageFormat.IF_BGR_ALPHA:
-        return IF_BGR_ALPHA_PREFERED;
+    /+case ImageFormat.IF_BGR_ALPHA:
+        return IF_BGR_ALPHA_PREFERED;+/
     case ImageFormat.IF_RGB:
         return IF_RGB_PREFERED;
-    case ImageFormat.IF_RGB_ALPHA:
-        return IF_RGB_ALPHA_PREFERED;
+    /+case ImageFormat.IF_RGB_ALPHA:
+        return IF_RGB_ALPHA_PREFERED;+/
     case ImageFormat.IF_YUV:
         return IF_YUV_PREFERED;
     default:
@@ -240,22 +245,22 @@ void adoptFormat(AVPixelFormat format, AVFrame* frame, ubyte[] data)
     {
         throw new Exception("Not implemented");
     }
-    else if (IF_RGB_ALPHA_TYPES.find(format))
+    /+else if (IF_RGB_ALPHA_TYPES.find(format))
     {
         throw new Exception("Not implemented");
     }
     else if (IF_BGR_ALPHA_TYPES.find(format))
     {
         throw new Exception("Not implemented");
-    }
+    }+/
     else if (IF_MONO_TYPES.find(format))
     {
         throw new Exception("Not implemented");
     }
-    else if (IF_MONO_ALPHA_TYPES.find(format))
+    /+else if (IF_MONO_ALPHA_TYPES.find(format))
     {
         throw new Exception("Not implemented");
-    }
+    }+/
     else
     {
         enforce(0, "Format type is not supported");

--- a/source/dcv/videoio/output.d
+++ b/source/dcv/videoio/output.d
@@ -441,18 +441,18 @@ void extractDataFromImage(in Image image, ref ubyte*[] data, ref int[] linesize)
         data = [image.data.ptr];
         linesize = [w];
         break;
-    case ImageFormat.IF_MONO_ALPHA:
+    /+case ImageFormat.IF_MONO_ALPHA:
         data = [image.data.ptr];
         linesize = [w * 2];
-        break;
+        break;+/
     case ImageFormat.IF_RGB, ImageFormat.IF_BGR:
         data = [image.data.ptr];
         linesize = [w * 3];
         break;
-    case ImageFormat.IF_RGB_ALPHA, ImageFormat.IF_BGR_ALPHA:
+    /+case ImageFormat.IF_RGB_ALPHA, ImageFormat.IF_BGR_ALPHA:
         data = [image.data.ptr];
         linesize = [w * 4];
-        break;
+        break;+/
     case ImageFormat.IF_YUV:
         data = [new ubyte[w * h].ptr, new ubyte[w * h].ptr, new ubyte[w * h].ptr];
         foreach (i; 0 .. pixelCount)


### PR DESCRIPTION
- [gamut](https://github.com/AuburnSounds/gamut) is an up-to-date solution for imageio. For imageio, dcv switched to gamut.
- Computer Vision has nothing to do with alpha channels, so the alpha channel was kept apart from imageio and videoio.
- A small bug in dcv.plot was fixed. It was an issue for some png images.