### PR TITLE
convertToRGB for videoio, update exmpl klt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ slice[0..$, 0..$, 1] // take the green channel only.
 waitKey();
 destroyFigures(); // free all allocated figures
 ```
-- In the new API, all functions accept slice shells as Slice!(T*, N) as input. On the other hand, API functions return RC-allocated Slice!(RCI!T, N). In this way, ref-counted slices can be passed to API functions like input.lightScope. It is recommended to avoid using lightScope in loop bodies; instead, create a lightScope outside of the loop body before using it. It has a performance bottleneck.
+- In the new API, all functions accept slice shells as Slice!(T*, N) as input. On the other hand, API functions return RC-allocated Slice!(RCI!T, N). In this way, ref-counted slices can be passed to API functions like input.lightScope. It is recommended to avoid using lightScope in loop bodies; instead, create a lightScope outside of the loop body before using it. It has a little cost.
 - nogc capabilities of mir libraries and dplug:core are utilized when needed.
 - ThreadPool of dplug:core is used in the entire library for parallelism.
 - class Image and class Figure use manual memory management. A call of function destroyFigures deallocates all allocated figures automatically. If an Image instance is initialized with non-null ubyte[] data, this time, the Image instance behaves like a slice shell, and it does not attempt to deallocate the borrowed data slice.

--- a/examples/tracking/klt/dub.json
+++ b/examples/tracking/klt/dub.json
@@ -5,7 +5,7 @@
     "authors": ["relja"],
     "dependencies": {
         "dcv:core": {"path": "../../../"},
-        "dcv:imageio": {"path": "../../../"},
+        "dcv:videoio": {"path": "../../../"},
         "dcv:plot": {"path": "../../../"}
     }
 }

--- a/examples/tracking/klt/source/app.d
+++ b/examples/tracking/klt/source/app.d
@@ -4,10 +4,10 @@ module dcv.example.opticalflow;
  * Kanade-Lucas-Tomasi tracking example, in dcv.
  */
 
-import std.stdio;
-import std.conv : to;
-import std.algorithm : copy, map, each, min;
-import std.range : lockstep, repeat;
+import core.stdc.stdio;
+import core.stdc.stdlib : exit, atof, atoi;
+
+import std.algorithm : min;
 import std.array : staticArray;
 import mir.ndslice;
 import mir.rc;
@@ -21,12 +21,15 @@ import dcv.features.corner.harris : shiTomasiCorners;
 import dcv.features.utils : extractCorners;
 import dcv.tracking.opticalflow : LucasKanadeFlow, SparsePyramidFlow;
 import dcv.plot;
+import dcv.videoio;
 
-import std.process;
+import dplug.core : CString;
+
+@nogc nothrow:
 
 void printHelp()
 {
-    writeln(`
+    printf(`
 DCV Lucas-Kanade Sparse Optical Flow Example.
 
 Run example program without arguments. This mode configures the flow algorithm by 
@@ -47,25 +50,63 @@ If multiple parameters are given, then parameters are considered to be:
 Example:
 ./klt -f ../../data/centaur_1.mpg 19 10 100 3 30 1000.0`);
 }
-enum H = 240;
-enum W = 320;
-
-// @nogc nothrow: // only pipeProcess allocates with GC
 
 int main(string[] args)
 {
-    auto pipes = pipeProcess(["ffmpeg", "-i", "../../data/centaur_1.mpg", "-f", "image2pipe",
-        "-vcodec", "rawvideo", "-pix_fmt", "rgb24", "-"],
-        Redirect.stdout);
+    InputStream inStream = mallocNew!InputStream;
+    scope(exit) destroyFree(inStream);
 
-    Slice!(RCI!float, 2) prevFrame, thisFrame; // image frames, for tracking
+    InputStreamType streamType;
+    string streamName;
 
-    auto cornerW = 15.0f; // size of the tracking kernel
-    auto cornerCount = 20; // numer of corners tracked
-    auto frames = 100; // maximum frame count to be tracked
-    auto pyrLevels = 3; // number of levels in the optical flow pyramid
-    auto iterCount = 10; // number of levels in the optical flow pyramid
-    auto eigLim = 1000.0f; // corner eigenvalue limit, after which the feature is invalid.
+    if (args.length == 1)
+    {
+        streamName = "../../data/centaur_1.mpg";
+        streamType = InputStreamType.FILE;
+    }
+    else
+    {
+        if (args.length < 3)
+        {
+            printf("Invalid argument setup - at least video format and stream name is needed.\n
+                   Call program with -h to show detailed info.");
+            return 1;
+        }
+
+        switch (args[1])
+        {
+        case "-f":
+            streamType = InputStreamType.FILE;
+            break;
+        case "-l":
+            streamType = InputStreamType.LIVE;
+            break;
+        default:
+            printf("Invalid video stream type: use -f for file and -l for webcam live stream\n");
+            return 1;
+        }
+
+        streamName = args[2];
+    }
+
+    if(streamType == InputStreamType.LIVE)
+        inStream.setVideoSizeRequest(640, 480);
+
+    inStream.open(streamName, streamType);
+
+    // Check if video has been opened correctly
+    if (!inStream.isOpen)
+    {
+        printf("Cannot open input video stream");
+        exit(-1);
+    }
+
+    auto cornerW = args.length >= 4 ? cast(float)args[3].CString.atof : 15.0f; // size of the tracking kernel
+    auto cornerCount = args.length >= 5 ? args[4].CString.atoi : 20; // numer of corners tracked
+    auto frames = args.length >= 6 ? args[5].CString.atoi : 100; // maximum frame count to be tracked
+    auto pyrLevels = args.length >= 7 ? args[6].CString.atoi : 3; // number of levels in the optical flow pyramid
+    auto iterCount = args.length >= 8 ? args[7].CString.atoi : 10; // number of levels in the optical flow pyramid
+    auto eigLim = args.length >= 9 ? cast(float)args[8].CString.atof : 1000.0f; // corner eigenvalue limit, after which the feature is invalid.
 
     // initialize and setup the optical flow algorithm
     LucasKanadeFlow lkFlow = mallocNew!LucasKanadeFlow;
@@ -82,33 +123,37 @@ int main(string[] args)
     scope(exit) freeSlice(reg);
     reg[] = [cornerW, cornerW].staticArray;
 
-    auto buffSlice = rcslice!ubyte([H, W, 3], 0);
-    auto figureKLT = imshow(buffSlice, "KLT");
-
+    Image aframe;
     // read first frame and use it to detect initial corners for tracking
-    const ubyte[] _dt = pipes.stdout.rawRead(buffSlice.ptr[0..H*W*3]);
+    inStream.readFrame(aframe);
+
+    Slice!(RCI!float, 2) prevFrame, thisFrame; // image frames, for tracking
 
     // take the r channel and form an image
-    prevFrame = buffSlice[0..$, 0..$, 0].as!float.rcslice;
+    prevFrame = aframe.sliced[0..$, 0..$, 0].as!float.rcslice;
 
-    auto h = prevFrame.shape[0];
-    auto w = prevFrame.shape[1];
+    auto h = aframe.height;
+    auto w = aframe.width;
+
+    auto buffSlice = rcslice!ubyte([h, w, 3], 0);
+    auto figureKLT = imshow(buffSlice, "KLT");
+
+    destroyFree(aframe);
+    aframe = null;
+
     auto frame = 0; // frame counter
 
-    while (1)
-    {
-        auto thisSlice = uninitRCslice!ubyte(h, w, 3);
-        const ubyte[] dt = pipes.stdout.rawRead(thisSlice.ptr[0..h*w*3]);
-        
-        printf("Tracking frame no. %d...\n", frame);
+    while (inStream.readFrame(aframe))
+    {   
+        debug printf("Tracking frame no. %d...\n", frame);
 
         // take the y channel, and form an image of it.
-        thisFrame = thisSlice[0 .. $, 0 .. $, 0].as!float.rcslice;
+        thisFrame = aframe.sliced[0 .. $, 0 .. $, 0].as!float.rcslice;
 
         // if corner count has dropped below 50% of original count, try to detect new points.
         if (corners.length < (cornerCount / 2))
         {
-            printf("Search features again...\n");
+            debug printf("Search features again...\n");
             
             auto c = shiTomasiCorners(prevFrame.lightScope, cast(uint)cornerW)
                 .filterNonMaximum.lightScope.extractCorners(cornerCount);
@@ -116,7 +161,7 @@ int main(string[] args)
             foreach (v; c)
                 corners.put([cast(float)v[0], cast(float)v[1]].staticArray);
         }
-
+        
         // evaluate the optical flow
         auto flow = spFlow.evaluate(prevFrame.lightScope, thisFrame.lightScope, corners.data, reg);
         
@@ -135,12 +180,12 @@ int main(string[] args)
             }
             else
             {
-                printf("Removing corner no. %zu with score: %f\n", id, e);
+                debug printf("Removing corner no. %zu with score: %f\n", id, e);
             }
         }
         
         // Displace previous corner coordinates with newly estimated flow vectors
-        // nogc lockStep workaround
+        // with nogc lockStep 
         auto A = corners.data.sliced;
         alias B = flow;
 
@@ -155,23 +200,25 @@ int main(string[] args)
             ++zipp;
         }
 
-        // draw tracked corners and write the image
-        auto f2c = thisFrame.lightScope.gray2rgb;
-
         // plot tracked points on screen.
-        figureKLT.draw(f2c, ImageFormat.IF_RGB);
+        figureKLT.draw(aframe);
         if(corners.data.length)
             figureKLT.plotPoints(corners.data);
+
+        // take this frame as next one's previous
+        prevFrame = thisFrame;
+        
+        scope(exit){
+            destroyFree(aframe);
+            aframe = null;
+        }
 
         if (waitKey(10) == KEY_ESCAPE)
             break;
 
-        if (++frame >= frames)
+        if(++frame >= frames && streamType == InputStreamType.FILE)
             break;
-
-        // take this frame as next one's previous
-        prevFrame = thisFrame;
-
+        
         if (!figureKLT.visible)
             break;
     }
@@ -189,4 +236,33 @@ void plotPoints(Figure handle, float[2][] corners){
     foreach(i; 0..xs.length){
         handle.drawCircle(PlotCircle(xs[i], ys[i], 5.0f), plotRed);
     }
+}
+
+bool parseArgs(in string[] args, out string path, out InputStreamType type)
+{
+    if (args.length == 1)
+        return true;
+    else if (args.length != 3)
+        return false;
+
+    type = InputStreamType.FILE;
+
+    switch (args[1])
+    {
+    case "-file":
+    case "-f":
+        type = InputStreamType.FILE;
+        break;
+    case "-live":
+    case "-l":
+        type = InputStreamType.LIVE;
+        break;
+    default:
+        printf("Invalid input type argument: ", args[2].ptr);
+        exit(-1);
+    }
+
+    path = args[2];
+
+    return true;
 }

--- a/examples/video/source/app.d
+++ b/examples/video/source/app.d
@@ -80,8 +80,9 @@ void main(string[] args)
         if (frame.format == ImageFormat.IF_YUV){
             auto toShow = frame.sliced.yuv2rgb!ubyte;
             fig.draw(toShow, ImageFormat.IF_RGB);
-        }else
+        }else{
             fig.draw(frame);
+        }
 
         destroyFree(frame);
         frame = null;

--- a/source/dcv/videoio/common.d
+++ b/source/dcv/videoio/common.d
@@ -296,8 +296,13 @@ void adoptYUV(AVPixelFormat format, AVFrame* frame, ref ubyte[] data)
         adoptYUV444P(frame, data);
         break;
     default:
-        assert(0);
+        break;
     }
+}
+
+void adoptRGB24(AVFrame* frame, ubyte[] data)
+{
+    data[] = frame.data[0][0 .. frame.width * frame.height *3];
 }
 
 void adoptYUVGrouped(AVFrame* frame, ref ubyte[] data)


### PR DESCRIPTION
InputStream inStream = mallocNew!InputStream(true) provides an automatic anyFormat ->RGB conversion. This resolves many issues related to reading from file and device video streams which may have a wide range of pixel formats.

readFrameImpl calls convertToRGB method doing RGB24 conversion via ffmpeg built-ins (there is a chance for hardware acceleration, etc.), if the input video stream is coded in any format other than RGB24.